### PR TITLE
Register code with punctuation

### DIFF
--- a/bin/industrial-classification.py
+++ b/bin/industrial-classification.py
@@ -59,20 +59,6 @@ for row in csv.DictReader(open(sys.argv[1]), delimiter=sep):
     codes[code] = row
 
 
-# take text from companies house list
-for row in csv.DictReader(open(sys.argv[2]), delimiter=sep):
-    code = row['industrial-classification']
-
-    # expand abbreviations
-    row['name'] = row['name'].replace('n.e.c.', 'not elsewhere classified')
-
-    if code not in codes:
-        print("skipping code", code, row['name'], file=sys.stderr)
-    else:
-        codes[code]['name'] = row['name']
-        codes[code]['name-cy'] = row['name-cy']
-
-
 print(sep.join(fields))
 for code in sorted(codes):
     row = codes[code]

--- a/bin/industrial-classification.py
+++ b/bin/industrial-classification.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 import re
 import sys
@@ -9,44 +8,56 @@ sep = '\t'
 
 section = ''
 
-industrial_classification = {}
+codes = {}
 parents = {}
 
+# make punctuated codes match those of Companies House
+def n7e(code):
+    if len(code) == 1:
+        return code
+
+    # compress punctuation from the code
+    code = re.sub("\D", "", code)
+
+    if len(code) == 4:
+        code = code + '0'
+
+    return code
+
+
+def parent_n7e(code, section):
+    code = n7e(code)
+    if len(code) == 1:
+        return ''
+
+    if len(code) == 2:
+        return section
+
+    if len(code) == 5:
+        if code[-1] == '0':
+            return code[:-2]
+        else:
+            return code[:-1] + '0'
+
+    return code[:-1]
+
+
+section = '*ERROR*'
 # read lists from the command line
 for row in csv.DictReader(open(sys.argv[1]), delimiter=sep):
-    code = row['industrial-classification']
+    code = n7e(row['industrial-classification'])
 
-    # set section
+    # assumes spreadsheet is ordered into sections ..
     if len(code) == 1:
-        section = code
-        parent = ''
-    else:
-        # compress punctuation from the code
-        code = re.sub("\D", "", row['industrial-classification'])
+        section = row['industrial-classification']
 
-        # make codes match those of Companies House
-        if len(code) == 4:
-            code = code + '0'
+    row['parent-code'] = parent_n7e(code, section)
 
-        # deduce parent code
-        if len(code) == 2:
-            parent = section
-        elif len(code) == 5:
-            if code[-1] == '0':
-                parent = code[:-2]
-            else:
-                parent = code[:-1] + '0'
-        else:
-            parent = code[:-1]
-
-    # expand abbreviations
+    # expand abbreviations in text ..
     row['name'] = row['name'].replace('n.e.c.', 'not elsewhere classified')
 
-    row['parent-industrial-classification'] = parent
-    row['industrial-classification'] = code
+    codes[code] = row
 
-
-    industrial_classification[row['industrial-classification']] = row
 
 # take text from companies house list
 for row in csv.DictReader(open(sys.argv[2]), delimiter=sep):
@@ -55,18 +66,18 @@ for row in csv.DictReader(open(sys.argv[2]), delimiter=sep):
     # expand abbreviations
     row['name'] = row['name'].replace('n.e.c.', 'not elsewhere classified')
 
-    if code not in industrial_classification:
+    if code not in codes:
         print("skipping code", code, row['name'], file=sys.stderr)
     else:
-        industrial_classification[code]['name'] = row['name']
-        industrial_classification[code]['name-cy'] = row['name-cy']
+        codes[code]['name'] = row['name']
+        codes[code]['name-cy'] = row['name-cy']
+
 
 print(sep.join(fields))
-for code in sorted(industrial_classification):
-    row = industrial_classification[code]
+for code in sorted(codes):
+    row = codes[code]
 
-    parent = row['parent-industrial-classification']
-    if parent and parent not in industrial_classification:
-        row['parent-industrial-classification'] = ''
+    if row['parent-code'] in codes:
+        row['parent-industrial-classification'] = codes[row['parent-code']]['industrial-classification']
 
     print(sep.join([row.get(field, '') for field in fields]))

--- a/data/industrial-classification/industrial-classification.tsv
+++ b/data/industrial-classification/industrial-classification.tsv
@@ -1,1188 +1,1188 @@
 industrial-classification	parent-industrial-classification	name	name-cy	start-date	end-date
 01	A	Crop and animal production, hunting and related service activities			
 01.1	01	Growing of non-perennial crops			
-01.11	01.1	Growing of cereals (except rice), leguminous crops and oil seeds	Tyfu grawn (ac eithrio reis), cnydau o godlysiau ac olew had		
-01.12	01.1	Growing of rice	Tyfu reis		
-01.13	01.1	Growing of vegetables and melons, roots and tubers	Tyfu llysiau a melonau,gwreiddlysiau a chloron		
-01.14	01.1	Growing of sugar cane	Tyfu câns siwgr		
-01.15	01.1	Growing of tobacco	Tyfu tybaco		
-01.16	01.1	Growing of fibre crops	Tyfu cnydau ffibrog		
-01.19	01.1	Growing of other non-perennial crops	Tyfu cnydau eraill nad ydynt yn gnydau lluosflwydd		
+01.11	01.1	Growing of cereals (except rice), leguminous crops and oil seeds			
+01.12	01.1	Growing of rice			
+01.13	01.1	Growing of vegetables and melons, roots and tubers			
+01.14	01.1	Growing of sugar cane			
+01.15	01.1	Growing of tobacco			
+01.16	01.1	Growing of fibre crops			
+01.19	01.1	Growing of other non-perennial crops			
 01.2	01	Growing of perennial crops			
-01.21	01.2	Growing of grapes	Tyfu grawnwin		
-01.22	01.2	Growing of tropical and subtropical fruits	Tyfu ffrwythau trofannol ac isdrofannol		
-01.23	01.2	Growing of citrus fruits	Tyfu ffrwythau sitrws		
-01.24	01.2	Growing of pome fruits and stone fruits	Tyfu ffrwythau o deulu'r afal a ffrwythau carreg		
-01.25	01.2	Growing of other tree and bush fruits and nuts	Tyfu cnau a ffrwythau coed a pherth eraill		
-01.26	01.2	Growing of oleaginous fruits	Tyfu ffrwythau olewaidd		
-01.27	01.2	Growing of beverage crops	Tyfu cnydau gwneud diodydd		
-01.28	01.2	Growing of spices, aromatic, drug and pharmaceutical crops	Tyfu cnydau sbeis, aromatig, cyffuriau a fferyllol		
-01.29	01.2	Growing of other perennial crops	Tyfu cnydau lluosflwydd eraill		
+01.21	01.2	Growing of grapes			
+01.22	01.2	Growing of tropical and subtropical fruits			
+01.23	01.2	Growing of citrus fruits			
+01.24	01.2	Growing of pome fruits and stone fruits			
+01.25	01.2	Growing of other tree and bush fruits and nuts			
+01.26	01.2	Growing of oleaginous fruits			
+01.27	01.2	Growing of beverage crops			
+01.28	01.2	Growing of spices, aromatic, drug and pharmaceutical crops			
+01.29	01.2	Growing of other perennial crops			
 01.3	01	Plant propagation			
-01.30	01.3	Plant propagation	Epilio planhigion		
+01.30	01.3	Plant propagation			
 01.4	01	Animal production			
-01.41	01.4	Raising of dairy cattle	Magu gwartheg godro		
-01.42	01.4	Raising of other cattle and buffaloes	Magu gwartheg eraill a byfflos		
-01.43	01.4	Raising of horses and other equines	Magu ceffylau ac anifeiliaid eraill o deulu'r ceffyl		
-01.44	01.4	Raising of camels and camelids	Magu camelod a chamelidau		
-01.45	01.4	Raising of sheep and  goats	Magu defaid a geifr		
-01.46	01.4	Raising of swine/pigs	Magu moch/anifeiliaid o deulu'r mochyn		
-01.47	01.4	Raising of poultry	Magu dofednod		
-01.49	01.4	Raising of other animals	Magu anifeiliaid eraill		
+01.41	01.4	Raising of dairy cattle			
+01.42	01.4	Raising of other cattle and buffaloes			
+01.43	01.4	Raising of horses and other equines			
+01.44	01.4	Raising of camels and camelids			
+01.45	01.4	Raising of sheep and goats			
+01.46	01.4	Raising of swine/pigs			
+01.47	01.4	Raising of poultry			
+01.49	01.4	Raising of other animals			
 01.5	01	Mixed farming			
-01.50	01.5	Mixed farming	Ffermio cymysg		
+01.50	01.5	Mixed farming			
 01.6	01	Support activities to agriculture and post-harvest crop activities			
-01.61	01.6	Support activities for crop production	Gweithgareddau cynorthwyol ym maes cynhyrchu cnydau		
+01.61	01.6	Support activities for crop production			
 01.62	01.6	Support activities for animal production			
-01.62/1	01.62	Farm animal boarding and care	Lletya a gofalu am anifeiliaid fferm		
-01.62/9	01.62	Support activities for animal production (other than farm animal boarding and care) not elsewhere classified	Gweithgareddau cynorthwyol ym maes magu anifeiliaid (ac eithrio lletya a gofalu am anifeiliaid fferm) n.dd.b.		
-01.63	01.6	Post-harvest crop activities	Gweithgareddau yn sgil cynaeafu cnydau		
-01.64	01.6	Seed processing for propagation	Prosesu hadau i'w hepilio		
+01.62/1	01.62	Farm animal boarding and care			
+01.62/9	01.62	Support activities for animal production (other than farm animal boarding and care) not elsewhere classified			
+01.63	01.6	Post-harvest crop activities			
+01.64	01.6	Seed processing for propagation			
 01.7	01	Hunting, trapping and related service activities			
-01.70	01.7	Hunting, trapping and related service activities	Hela, maglu a gweithgareddau'r gwasanaethau cysylltiedig		
+01.70	01.7	Hunting, trapping and related service activities			
 02	A	Forestry and logging			
 02.1	02	Silviculture and other forestry activities			
-02.10	02.1	Silviculture and other forestry activities	Tyfu coed a gweithgareddau coedwigaeth eraill		
+02.10	02.1	Silviculture and other forestry activities			
 02.2	02	Logging			
-02.20	02.2	Logging	Torri coed yn foncyffion		
+02.20	02.2	Logging			
 02.3	02	Gathering of wild growing non-wood products			
-02.30	02.3	Gathering of wild growing non-wood products	Casglu cynnyrch sy'n tyfu'n wyllt heblaw pren		
+02.30	02.3	Gathering of wild growing non-wood products			
 02.4	02	Support services to forestry			
-02.40	02.4	Support services to forestry	Gwasanaethau cynorthwyol ym maes coedwigaeth		
+02.40	02.4	Support services to forestry			
 03	A	Fishing and aquaculture			
 03.1	03	Fishing			
-03.11	03.1	Marine fishing	Pysgota morol		
-03.12	03.1	Freshwater fishing	Pysgota dŵr croyw		
+03.11	03.1	Marine fishing			
+03.12	03.1	Freshwater fishing			
 03.2	03	Aquaculture			
-03.21	03.2	Marine aquaculture	Acwafeithrin morol		
-03.22	03.2	Freshwater aquaculture	Acwafeithrin mewn dŵr croyw		
+03.21	03.2	Marine aquaculture			
+03.22	03.2	Freshwater aquaculture			
 05	B	Mining of coal and lignite			
 05.1	05	Mining of hard coal			
 05.10	05.1	Mining of hard coal			
-05.10/1	05.10	Deep coal mines	Pyllau glo dwfn		
-05.10/2	05.10	Open cast coal working	Cloddfeydd glo brig		
+05.10/1	05.10	Mining of hard coal from deep coal mines (underground mining)			
+05.10/2	05.10	Mining of hard coal from open cast coal working (surface mining)			
 05.2	05	Mining of lignite			
-05.20	05.2	Mining of lignite	Mwyngloddio coedlo (lignit)		
+05.20	05.2	Mining of lignite			
 06	B	Extraction of crude petroleum and natural gas			
 06.1	06	Extraction of crude petroleum			
-06.10	06.1	Extraction of crude petroleum	Echdynnu petrolewm crai		
+06.10	06.1	Extraction of crude petroleum			
 06.2	06	Extraction of natural gas			
-06.20	06.2	Extraction of natural gas	Echdynnu nwyon naturiol		
+06.20	06.2	Extraction of natural gas			
 07	B	Mining of metal ores			
 07.1	07	Mining of iron ores			
-07.10	07.1	Mining of iron ores	Mwyngloddio mwynau haearn		
+07.10	07.1	Mining of iron ores			
 07.2	07	Mining of non-ferrous metal ores			
-07.21	07.2	Mining of uranium and thorium ores	Mwyngloddio mwynau wraniwm a thoriwm		
-07.29	07.2	Mining of other non-ferrous metal ores	Mwyngloddio mwynau metel anfferrus eraill		
+07.21	07.2	Mining of uranium and thorium ores			
+07.29	07.2	Mining of other non-ferrous metal ores			
 08	B	Other mining and quarrying			
 08.1	08	Quarrying of stone, sand and clay			
-08.11	08.1	Quarrying of ornamental and building stone, limestone, gypsum, chalk and slate	Chwarela cerrig addurnol a cherrig adeiladu, calchfaen, gypswm, sialc a llechi		
-08.12	08.1	Operation of gravel and sand pits; mining of clays and kaolin	Gweithredu pyllau graean a thywod; mwyngloddio clai a chaolin		
+08.11	08.1	Quarrying of ornamental and building stone, limestone, gypsum, chalk and slate			
+08.12	08.1	Operation of gravel and sand pits; mining of clays and kaolin			
 08.9	08	Mining and quarrying not elsewhere classified			
-08.91	08.9	Mining of chemical and fertilizer minerals	Mwyngloddio mwynau cemegol a gwrteithio		
-08.92	08.9	Extraction of peat	Echdynnu mawn		
-08.93	08.9	Extraction of salt	Echdynnu halen		
-08.99	08.9	Other mining and quarrying not elsewhere classified	Gweithgareddau mwyngloddio a chwarela eraill n.dd.b.		
+08.91	08.9	Mining of chemical and fertiliser minerals			
+08.92	08.9	Extraction of peat			
+08.93	08.9	Extraction of salt			
+08.99	08.9	Other mining and quarrying not elsewhere classified			
 09	B	Mining support service activities			
 09.1	09	Support activities for petroleum and natural gas extraction			
-09.10	09.1	Support activities for petroleum and natural gas mining	Gweithgareddau cynorthwyol ym maes mwyngloddio petrolewm a nwy naturiol		
+09.10	09.1	Support activities for petroleum and natural gas extraction			
 09.9	09	Support activities for other mining and quarrying			
-09.90	09.9	Support activities for other mining and quarrying	Gweithgareddau cynorthwyol mwyngloddio a chwarela arall		
+09.90	09.9	Support activities for other mining and quarrying			
 10	C	Manufacture of food products			
 10.1	10	Processing and preserving of meat and production of meat products			
-10.11	10.1	Processing and preserving of meat	Prosesu a chyffeithio cig		
-10.12	10.1	Processing and preserving of poultry meat	Prosesu a chyffeithio cig dofednod		
-10.13	10.1	Production of meat and poultry meat products	Cynhyrchu cynhyrchion cig a dofednod		
+10.11	10.1	Processing and preserving of meat			
+10.12	10.1	Processing and preserving of poultry meat			
+10.13	10.1	Production of meat and poultry meat products			
 10.2	10	Processing and preserving of fish, crustaceans and molluscs			
-10.20	10.2	Processing and preserving of fish, crustaceans and molluscs	Prosesu a chyffeithio pysgod, cramenogion a molysgiaid		
+10.20	10.2	Processing and preserving of fish, crustaceans and molluscs			
 10.3	10	Processing and preserving of fruit and vegetables			
-10.31	10.3	Processing and preserving of potatoes	Prosesu a chyffeithio tatws		
-10.32	10.3	Manufacture of fruit and vegetable juice	Gweithgynhyrchu sudd ffrwythau a llysiau		
-10.39	10.3	Other processing and preserving of fruit and vegetables	Prosesu a chyffeithio ffrwythau a llysiau at ddibenion eraill		
+10.31	10.3	Processing and preserving of potatoes			
+10.32	10.3	Manufacture of fruit and vegetable juice			
+10.39	10.3	Other processing and preserving of fruit and vegetables			
 10.4	10	Manufacture of vegetable and animal oils and fats			
-10.41	10.4	Manufacture of oils and fats	Gweithgynhyrchu olewon a brasterau		
-10.42	10.4	Manufacture of margarine and similar edible fats	Gweithgynhyrchu margarin a brasterau bwytadwy tebyg		
+10.41	10.4	Manufacture of oils and fats			
+10.42	10.4	Manufacture of margarine and similar edible fats			
 10.5	10	Manufacture of dairy products			
 10.51	10.5	Operation of dairies and cheese making			
-10.51/1	10.51	Liquid milk and cream production	Cynhyrchu llaeth a hufen hylifol		
-10.51/2	10.51	Butter and cheese production	Cynhyrchu menyn a chaws		
-10.51/9	10.51	Manufacture of other milk products	Gweithgynhyrchu cynnyrch llaeth arall		
-10.52	10.5	Manufacture of ice cream	Gweithgynhyrchu hufen iâ		
+10.51/1	10.51	Liquid milk and cream production			
+10.51/2	10.51	Butter and cheese production			
+10.51/9	10.51	Manufacture of milk products (other than liquid milk and cream, butter, cheese) not elsewhere classified			
+10.52	10.5	Manufacture of ice cream			
 10.6	10	Manufacture of grain mill products, starches and starch products			
 10.61	10.6	Manufacture of grain mill products			
-10.61/1	10.61	Grain milling	Melino grawn		
-10.61/2	10.61	Manufacture of breakfast cereals and cereals-based food	Gweithgynhyrchu grawnfwydydd brecwast a grawnfwydydd eraill		
-10.62	10.6	Manufacture of starches and starch products	Gweithgynhyrchu startsh a chynnyrch startsh		
+10.61/1	10.61	Grain milling			
+10.61/2	10.61	Manufacture of breakfast cereals and cereals-based foods			
+10.62	10.6	Manufacture of starches and starch products			
 10.7	10	Manufacture of bakery and farinaceous products			
-10.71	10.7	Manufacture of bread; manufacture of fresh pastry goods and cakes	Gweithgynhyrchu bara; gweithgynhyrchu teisennau a chacennau ffres		
-10.72	10.7	Manufacture of rusks and biscuits; manufacture of preserved pastry goods and cakes	Gweithgynhyrchu rhysgenni a bisgedi; gweithgynhyrchu teisennau a chacennau cadw		
-10.73	10.7	Manufacture of macaroni, noodles, couscous and similar farinaceous products	Gweithgynhyrchu macaroni, nwdls, couscous a chynnyrch cannog tebyg		
+10.71	10.7	Manufacture of bread; manufacture of fresh pastry goods and cakes			
+10.72	10.7	Manufacture of rusks and biscuits; manufacture of preserved pastry goods and cakes			
+10.73	10.7	Manufacture of macaroni, noodles, couscous and similar farinaceous products			
 10.8	10	Manufacture of other food products			
-10.81	10.8	Manufacture of sugar	Gweithgynhyrchu siwgr		
+10.81	10.8	Manufacture of sugar			
 10.82	10.8	Manufacture of cocoa, chocolate and sugar confectionery			
-10.82/1	10.82	Manufacture of cocoa and chocolate confectionery	Gweithgynhyrchu melysion coco a siocled		
-10.82/2	10.82	Manufacture of sugar confectionery	Gweithgynhyrchu melysion siwgr		
+10.82/1	10.82	Manufacture of cocoa, and chocolate confectionery			
+10.82/2	10.82	Manufacture of sugar confectionery			
 10.83	10.8	Processing of tea and coffee			
-10.83/1	10.83	Tea processing	Prosesu te		
-10.83/2	10.83	Production of coffee and coffee substitutes	Cynhyrchu coffi ac amnewidion coffi		
-10.84	10.8	Manufacture of condiments and seasonings	Gweithgynhyrchu confennau a sesnin		
-10.85	10.8	Manufacture of prepared meals and dishes	Gweithgynhyrchu prydau a seigiau parod		
-10.86	10.8	Manufacture of homogenized food preparations and dietetic food	Gweithgynhyrchu bwydydd homogenaidd a lluniaethol		
-10.89	10.8	Manufacture of other food products not elsewhere classified	Gweithgynhyrchu cynnyrch bwyd arall n.dd.b.		
+10.83/1	10.83	Tea processing			
+10.83/2	10.83	Production of coffee and coffee substitutes			
+10.84	10.8	Manufacture of condiments and seasonings			
+10.85	10.8	Manufacture of prepared meals and dishes			
+10.86	10.8	Manufacture of homogenised food preparations and dietetic food			
+10.89	10.8	Manufacture of other food products not elsewhere classified			
 10.9	10	Manufacture of prepared animal feeds			
-10.91	10.9	Manufacture of prepared feeds for farm animals	Gweithgynhyrchu bwydydd parod ar gyfer anifeiliaid fferm		
-10.92	10.9	Manufacture of prepared pet foods	Gweithgynhyrchu bwydydd parod ar gyfer anifeiliaid anwes		
+10.91	10.9	Manufacture of prepared feeds for farm animals			
+10.92	10.9	Manufacture of prepared pet foods			
 11	C	Manufacture of beverages			
 11.0	11	Manufacture of beverages			
-11.01	11.0	Distilling, rectifying and blending of spirits	Distyllu, puro a chymysgu gwirodydd		
-11.02	11.0	Manufacture of wine from grape	Gweithgynhyrchu gwin o rawnwin		
-11.03	11.0	Manufacture of cider and other fruit wines	Gweithgynhyrchu seidr a mathau eraill o winoedd ffrwyth		
-11.04	11.0	Manufacture of other non-distilled fermented beverages	Gweithgynhyrchu diodydd brag eraill heb eu distyllu		
-11.05	11.0	Manufacture of beer	Gweithgynhyrchu cwrw		
-11.06	11.0	Manufacture of malt	Gweithgynhyrchu brag		
-11.07	11.0	Manufacture of soft drinks; production of mineral waters and other bottled waters	Gweithgynhyrchu diodydd ysgafn; cynhyrchu dŵr mwynol a dŵr potel arall		
+11.01	11.0	Distilling, rectifying and blending of spirits			
+11.02	11.0	Manufacture of wine from grape			
+11.03	11.0	Manufacture of cider and other fruit wines			
+11.04	11.0	Manufacture of other non-distilled fermented beverages			
+11.05	11.0	Manufacture of beer			
+11.06	11.0	Manufacture of malt			
+11.07	11.0	Manufacture of soft drinks; production of mineral waters and other bottled waters			
 12	C	Manufacture of tobacco products			
 12.0	12	Manufacture of tobacco products			
-12.00	12.0	Manufacture of tobacco products	Gweithgynhyrchu cynnyrch tybaco		
+12.00	12.0	Manufacture of tobacco products			
 13	C	Manufacture of textiles			
 13.1	13	Preparation and spinning of textile fibres			
-13.10	13.1	Preparation and spinning of textile fibres	Paratoi a nyddu ffibrau gweol		
+13.10	13.1	Preparation and spinning of textile fibres			
 13.2	13	Weaving of textiles			
-13.20	13.2	Weaving of textiles	Gwehyddu tecstilau		
+13.20	13.2	Weaving of textiles			
 13.3	13	Finishing of textiles			
-13.30	13.3	Finishing of textiles	Gorffennu tecstilau		
+13.30	13.3	Finishing of textiles			
 13.9	13	Manufacture of other textiles			
-13.91	13.9	Manufacture of knitted and crocheted fabrics	Gweithgynhyrchu ffabrig wedi'i wau a'i grosio		
+13.91	13.9	Manufacture of knitted and crocheted fabrics			
 13.92	13.9	Manufacture of made-up textile articles, except apparel			
-13.92/1	13.92	Manufacture of soft furnishings	Gweithgynhyrchu dodrefn meddal		
-13.92/2	13.92	manufacture of canvas goods, sacks, etc.	Gweithgynhyrchu nwyddau cynfas, sachau ac ati		
-13.92/3	13.92	manufacture of household textiles	Gweithgynhyrchu tecstilau cartref		
+13.92/1	13.92	Manufacture of soft furnishings			
+13.92/2	13.92	Manufacture of canvas goods, sacks etc.			
+13.92/3	13.92	Manufacture of household textiles (other than soft furnishings of 13.92/1)			
 13.93	13.9	Manufacture of carpets and rugs			
-13.93/1	13.93	Manufacture of woven or tufted carpets and rugs	Gweithgynhyrchu carpedi a rygiau codennog neu wedi'u gwehyddu		
-13.93/9	13.93	Manufacture of other carpets and rugs	Gweithgynhyrchu carpedi a rygiau eraill		
-13.94	13.9	Manufacture of cordage, rope, twine and netting	Gweithgynhyrchu deunyddiau rhaffog, rhaffau, cortynnau a rhwydi		
-13.95	13.9	Manufacture of non-wovens and articles made from non-wovens, except apparel	Gweithgynhyrchu nwyddau heb eu gwehyddu a nwyddau o ddeunyddiau heb eu gwehyddu, ac eithrio dillad		
-13.96	13.9	Manufacture of other technical and industrial textiles	Gweithgynhyrchu tecstilau technegol a diwydiannol eraill		
-13.99	13.9	Manufacture of other textiles not elsewhere classified	Gweithgynhyrchu tecstilau eraill n.dd.b.		
+13.93/1	13.93	Manufacture of woven or tufted carpets and rugs			
+13.93/9	13.93	Manufacture of carpets and rugs (other than woven or tufted) not elsewhere classified			
+13.94	13.9	Manufacture of cordage, rope, twine and netting			
+13.95	13.9	Manufacture of non-wovens and articles made from non-wovens, except apparel			
+13.96	13.9	Manufacture of other technical and industrial textiles			
+13.99	13.9	Manufacture of other textiles not elsewhere classified			
 14	C	Manufacture of wearing apparel			
 14.1	14	Manufacture of wearing apparel, except fur apparel			
-14.11	14.1	Manufacture of leather clothes	Gweithgynhyrchu dillad lledr		
-14.12	14.1	Manufacture of workwear	Gweithgynhyrchu dillad gwaith		
+14.11	14.1	Manufacture of leather clothes			
+14.12	14.1	Manufacture of workwear			
 14.13	14.1	Manufacture of other outerwear			
-14.13/1	14.13	Manufacture of other men's outerwear	Gweithgynhyrchu dillad uchaf eraill i ddynion		
-14.13/2	14.13	Manufacture of other women's outerwear	Gweithgynhyrchu dillad uchaf eraill i fenywod		
+14.13/1	14.13	Manufacture of men's outerwear, other than leather clothes and workwear			
+14.13/2	14.13	Manufacture of women's outerwear, other than leather clothes and workwear			
 14.14	14.1	Manufacture of underwear			
-14.14/1	14.14	Manufacture of men's underwear	Gweithgynhyrchu dillad isaf i ddynion		
-14.14/2	14.14	Manufacture of women's underwear	Gweithgynhyrchu dillad isaf i fenywod		
-14.19	14.1	Manufacture of other wearing apparel and accessories not elsewhere classified	Gweithgynhyrchu dillad ac ategolion eraill n.dd.b.		
+14.14/1	14.14	Manufacture of men's underwear			
+14.14/2	14.14	Manufacture of women's underwear			
+14.19	14.1	Manufacture of other wearing apparel and accessories			
 14.2	14	Manufacture of articles of fur			
-14.20	14.2	Manufacture of articles of fur	Gweithgynhyrchu eitemau ffwr		
+14.20	14.2	Manufacture of articles of fur			
 14.3	14	Manufacture of knitted and crocheted apparel			
-14.31	14.3	Manufacture of knitted and crocheted hosiery	Gweithgynhyrchu hosanwaith wedi'i wau a'i grosio		
-14.39	14.3	Manufacture of other knitted and crocheted apparel	Gweithgynhyrchu dillad eraill wedi'i gwau a’u crosio		
+14.31	14.3	Manufacture of knitted and crocheted hosiery			
+14.39	14.3	Manufacture of other knitted and crocheted apparel			
 15	C	Manufacture of leather and related products			
 15.1	15	Tanning and dressing of leather; manufacture of luggage, handbags, saddlery and harness; dressing and dyeing of fur			
-15.11	15.1	Tanning and dressing of leather; dressing and dyeing of fur	Barcio a thrin lledr; trin a lliwio ffwr		
-15.12	15.1	Manufacture of luggage, handbags and the like, saddlery and harness	Gweithgynhyrchu bagiau, bagiau llaw ac ati, cyfrwyon a harneisi		
+15.11	15.1	Tanning and dressing of leather; dressing and dyeing of fur			
+15.12	15.1	Manufacture of luggage, handbags and the like, saddlery and harness			
 15.2	15	Manufacture of footwear			
-15.20	15.2	Manufacture of footwear	Gweithgynhyrchu esgidiau		
+15.20	15.2	Manufacture of footwear			
 16	C	Manufacture of wood and of products of wood and cork, except furniture; manufacture of articles of straw and plaiting materials			
 16.1	16	Sawmilling and planing of wood			
-16.10	16.1	Sawmilling and planing of wood	Llifio a phlaenio pren		
+16.10	16.1	Sawmilling and planing of wood			
 16.2	16	Manufacture of products of wood, cork, straw and plaiting materials			
-16.21	16.2	Manufacture of veneer sheets and wood-based panels	Gweithgynhyrchu dalenni argaen a phaneli o bren		
-16.22	16.2	Manufacture of assembled parquet floors	Gweithgynhyrchu lloriau parquet parod		
-16.23	16.2	Manufacture of other builders' carpentry and joinery	Gweithgynhyrchu gwaith coed a gwaith saer arall ar gyfer adeiladwyr		
-16.24	16.2	Manufacture of wooden containers	Gweithgynhyrchu cynwysyddion pren		
-16.29	16.2	Manufacture of other products of wood; manufacture of articles of cork, straw and plaiting materials	Gweithgynhyrchu cynhyrchion pren eraill; gweithgynhyrchu deunyddiau corc, gwellt a phleth		
+16.21	16.2	Manufacture of veneer sheets and wood-based panels			
+16.22	16.2	Manufacture of assembled parquet floors			
+16.23	16.2	Manufacture of other builders' carpentry and joinery			
+16.24	16.2	Manufacture of wooden containers			
+16.29	16.2	Manufacture of other products of wood; manufacture of articles of cork, straw and plaiting materials			
 17	C	Manufacture of paper and paper products			
 17.1	17	Manufacture of pulp, paper and paperboard			
-17.11	17.1	Manufacture of pulp	Gweithgynhyrchu mwydion pren		
-17.12	17.1	Manufacture of paper and paperboard	Gweithgynhyrchu papur a bwrdd papur		
+17.11	17.1	Manufacture of pulp			
+17.12	17.1	Manufacture of paper and paperboard			
 17.2	17	Manufacture of articles of paper and paperboard			
 17.21	17.2	Manufacture of corrugated paper and paperboard and of containers of paper and paperboard			
-17.21/1	17.21	Manufacture of corrugated paper and paperboard, sacks and bags	Gweithgynhyrchu papur rhychiog a bwrdd papur, sachau a bagiau		
-17.21/9	17.21	Manufacture of other paper and paperboard containers	Gweithgynhyrchu cynwysyddion eraill o bapur a bwrdd papur		
-17.22	17.2	Manufacture of household and sanitary goods and of toilet requisites	Gweithgynhyrchu nwyddau cartref, iechydol a thŷ bach		
-17.23	17.2	Manufacture of paper stationery	Gweithgynhyrchu deunyddiau ysgrifennu papur		
-17.24	17.2	Manufacture of wallpaper	Gweithgynhyrchu papur wal		
-17.29	17.2	Manufacture of other articles of paper and paperboard not elsewhere classified	Gweithgynhyrchu eitemau eraill o bapur a bwrdd papur n.dd.b.		
+17.21/1	17.21	Manufacture of corrugated paper and paperboard; manufacture of sacks and bags of paper			
+17.21/9	17.21	Manufacture of paper and paperboard containers other than sacks and bags			
+17.22	17.2	Manufacture of household and sanitary goods and of toilet requisites			
+17.23	17.2	Manufacture of paper stationery			
+17.24	17.2	Manufacture of wallpaper			
+17.29	17.2	Manufacture of other articles of paper and paperboard			
 18	C	Printing and reproduction of recorded media			
 18.1	18	Printing and service activities related to printing			
-18.11	18.1	Printing of newspapers	Argraffu papurau newydd		
+18.11	18.1	Printing of newspapers			
 18.12	18.1	Other printing			
-18.12/1	18.12	Manufacture of printed labels	Gweithgynhyrchu labeli printiedig		
-18.12/9	18.12	Printing not elsewhere classified	Argraffu n.dd.b.		
-18.13	18.1	Pre-press and pre-media services	Gwasanaethau paratoi ar gyfer y wasg a'r cyfryngau		
-18.14	18.1	Binding and related services	Rhwymo a gwasanaethau cysylltiedig		
+18.12/1	18.12	Manufacture of printed labels			
+18.12/9	18.12	Printing (other than printing of newspapers and printing on labels and tags) not elsewhere classified			
+18.13	18.1	Pre-press and pre-media services			
+18.14	18.1	Binding and related services			
 18.2	18	Reproduction of recorded media			
 18.20	18.2	Reproduction of recorded media			
-18.20/1	18.20	Reproduction of sound recording	Atgynhyrchu recordiadau sain		
-18.20/2	18.20	Reproduction of video recording	Atgynhyrchu recordiadau fideo		
-18.20/3	18.20	Reproduction of computer media	Atgynhyrchu cyfryngau cyfrifiadurol		
+18.20/1	18.20	Reproduction of sound recording			
+18.20/2	18.20	Reproduction of video recording			
+18.20/3	18.20	Reproduction of computer media			
 19	C	Manufacture of coke and refined petroleum products			
 19.1	19	Manufacture of coke oven products			
-19.10	19.1	Manufacture of coke oven products	Gweithgynhyrchu cynhyrchion ffwrn golosg		
+19.10	19.1	Manufacture of coke oven products			
 19.2	19	Manufacture of refined petroleum products			
 19.20	19.2	Manufacture of refined petroleum products			
-19.20/1	19.20	Mineral oil refining	Puro olewon mwynol		
-19.20/9	19.20	Other treatment of petroleum products (excluding petrochemicals manufacture)	Trin cynhyrchion petrolewm eraill (ac eithrio gweithgynhyrchu petrocemegion)		
+19.20/1	19.20	Mineral oil refining			
+19.20/9	19.20	Other treatment of petroleum products (excluding mineral oil refining/petrochemicals manufacture)			
 20	C	Manufacture of chemicals and chemical products			
 20.1	20	Manufacture of basic chemicals, fertilisers and nitrogen compounds, plastics and synthetic rubber in primary forms			
-20.11	20.1	Manufacture of industrial gases	Gweithgynhyrchu nwyon diwydiannol		
-20.12	20.1	Manufacture of dyes and pigments	Gweithgynhyrchu lifynnau a phigmentau		
-20.13	20.1	Manufacture of other inorganic basic chemicals	Gweithgynhyrchu cemegion sylfaenol anorganig eraill		
-20.14	20.1	Manufacture of other organic basic chemicals	Gweithgynhyrchu cemegion sylfaenol organig eraill		
-20.15	20.1	Manufacture of fertilizers and nitrogen compounds	Gweithgynhyrchu gwrtaith a chyfansoddion nitrogen		
-20.16	20.1	Manufacture of plastics in primary forms	Gweithgynhyrchu plastig ar ei ffurf sylfaenol		
-20.17	20.1	Manufacture of synthetic rubber in primary forms	Gweithgynhyrchu rwber synthetig ar ei ffurf sylfaenol		
+20.11	20.1	Manufacture of industrial gases			
+20.12	20.1	Manufacture of dyes and pigments			
+20.13	20.1	Manufacture of other inorganic basic chemicals			
+20.14	20.1	Manufacture of other organic basic chemicals			
+20.15	20.1	Manufacture of fertilisers and nitrogen compounds			
+20.16	20.1	Manufacture of plastics in primary forms			
+20.17	20.1	Manufacture of synthetic rubber in primary forms			
 20.2	20	Manufacture of pesticides and other agrochemical products			
-20.20	20.2	Manufacture of pesticides and other agrochemical products	Gweithgynhyrchu plaladdwyr a chynnyrch agrocemegol		
+20.20	20.2	Manufacture of pesticides and other agrochemical products			
 20.3	20	Manufacture of paints, varnishes and similar coatings, printing ink and mastics			
 20.30	20.3	Manufacture of paints, varnishes and similar coatings, printing ink and mastics			
-20.30/1	20.30	Manufacture of paints, varnishes and similar coatings, mastics and sealants	Gweithgynhyrchu paent, farnais a chaenau, mastigau a deunyddiau selio tebyg eraill		
-20.30/2	20.30	Manufacture of printing ink	Gweithgynhyrchu inc argraffu		
+20.30/1	20.30	Manufacture of paints, varnishes and similar coatings, mastics and sealants			
+20.30/2	20.30	Manufacture of printing ink			
 20.4	20	Manufacture of soap and detergents, cleaning and polishing preparations, perfumes and toilet preparations			
 20.41	20.4	Manufacture of soap and detergents, cleaning and polishing preparations			
-20.41/1	20.41	Manufacture of soap and detergents	Gweithgynhyrchu sebon a glanedyddion		
-20.41/2	20.41	Manufacture of cleaning and polishing preparations	Gweithgynhyrchu cymysgeddau glanhau a chaboli		
-20.42	20.4	Manufacture of perfumes and toilet preparations	Gweithgynhyrchu persawrau a chymysgeddau ymolchi		
+20.41/1	20.41	Manufacture of soap and detergents			
+20.41/2	20.41	Manufacture of cleaning and polishing preparations			
+20.42	20.4	Manufacture of perfumes and toilet preparations			
 20.5	20	Manufacture of other chemical products			
-20.51	20.5	Manufacture of explosives	Gweithgynhyrchu ffrwydron		
-20.52	20.5	Manufacture of glues	Gweithgynhyrchu glud		
-20.53	20.5	Manufacture of essential oils	Gweithgynhyrchu olewon naws		
-20.59	20.5	Manufacture of other chemical products not elsewhere classified	Gweithgynhyrchu cynhyrchion cemegol eraill n.dd.b.		
+20.51	20.5	Manufacture of explosives			
+20.52	20.5	Manufacture of glues			
+20.53	20.5	Manufacture of essential oils			
+20.59	20.5	Manufacture of other chemical products not elsewhere classified			
 20.6	20	Manufacture of man-made fibres			
-20.60	20.6	Manufacture of man-made fibres	Gweithgynhyrchu ffibrau gwneud		
+20.60	20.6	Manufacture of man-made fibres			
 21	C	Manufacture of basic pharmaceutical products and pharmaceutical preparations			
 21.1	21	Manufacture of basic pharmaceutical products			
-21.10	21.1	Manufacture of basic pharmaceutical products	Gweithgynhyrchu cynhyrchion fferyllol sylfaenol		
+21.10	21.1	Manufacture of basic pharmaceutical products			
 21.2	21	Manufacture of pharmaceutical preparations			
-21.20	21.2	Manufacture of pharmaceutical preparations	Gweithgynhyrchu cymysgeddau fferyllol		
+21.20	21.2	Manufacture of pharmaceutical preparations			
 22	C	Manufacture of rubber and plastic products			
 22.1	22	Manufacture of rubber products			
-22.11	22.1	Manufacture of rubber tyres and tubes; retreading and rebuilding of rubber tyres	Gweithgynhyrchu teiars a thiwbiau rwber; adfer ac ailwampio teiars rwber		
-22.19	22.1	Manufacture of other rubber products	Gweithgynhyrchu cynhyrchion rwber eraill		
+22.11	22.1	Manufacture of rubber tyres and tubes; retreading and rebuilding of rubber tyres			
+22.19	22.1	Manufacture of other rubber products			
 22.2	22	Manufacture of plastics products			
-22.21	22.2	Manufacture of plastic plates, sheets, tubes and profiles	Gweithgynhyrchu platiau, dalenni, tiwbiau a phroffiliau plastig		
-22.22	22.2	Manufacture of plastic packing goods	Gweithgynhyrchu nwyddau pacio plastig		
-22.23	22.2	Manufacture of builders  ware of plastic	Gweithgynhyrchu deunydd adeiladu o blastig		
-22.29	22.2	Manufacture of other plastic products	Gweithgynhyrchu cynhyrchion plastig eraill		
+22.21	22.2	Manufacture of plastic plates, sheets, tubes and profiles			
+22.22	22.2	Manufacture of plastic packing goods			
+22.23	22.2	Manufacture of builders’ ware of plastic			
+22.29	22.2	Manufacture of other plastic products			
 23	C	Manufacture of other non-metallic mineral products			
 23.1	23	Manufacture of glass and glass products			
-23.11	23.1	Manufacture of flat glass	Gweithgynhyrchu gwydr gwastad		
-23.12	23.1	Shaping and processing of flat glass	Siapio a phrosesu gwydr gwastad		
-23.13	23.1	Manufacture of hollow glass	Gweithgynhyrchu gwydr cau		
-23.14	23.1	Manufacture of glass fibres	Gweithgynhyrchu ffibrau gwydr		
-23.19	23.1	Manufacture and processing of other glass, including technical glassware	Gweithgynhyrchu a phrosesu gwydrau eraill, gan gynnwys llestri gwydr technegol		
+23.11	23.1	Manufacture of flat glass			
+23.12	23.1	Shaping and processing of flat glass			
+23.13	23.1	Manufacture of hollow glass			
+23.14	23.1	Manufacture of glass fibres			
+23.19	23.1	Manufacture and processing of other glass, including technical glassware			
 23.2	23	Manufacture of refractory products			
-23.20	23.2	Manufacture of refractory products	Gweithgynhyrchu cynhyrchion gwrthsafol		
+23.20	23.2	Manufacture of refractory products			
 23.3	23	Manufacture of clay building materials			
-23.31	23.3	Manufacture of ceramic tiles and flags	Gweithgynhyrchu teils a cherrig llorio serameg		
-23.32	23.3	Manufacture of bricks, tiles and construction products, in baked clay	Gweithgynhyrchu brics, teils a chynhyrchion adeiladu clai cras		
+23.31	23.3	Manufacture of ceramic tiles and flags			
+23.32	23.3	Manufacture of bricks, tiles and construction products, in baked clay			
 23.4	23	Manufacture of other porcelain and ceramic products			
-23.41	23.4	Manufacture of ceramic household and ornamental articles	Gweithgynhyrchu nwyddau cartref ac addurnol seramig		
-23.42	23.4	Manufacture of ceramic sanitary fixtures	Gweithgynhyrchu offer iechydol seramig		
-23.43	23.4	Manufacture of ceramic insulators and insulating fittings	Gweithgynhyrchu ynysyddion ac offer ynysu seramig		
-23.44	23.4	Manufacture of other technical ceramic products	Gweithgynhyrchu cynhyrchion technegol seramig eraill		
-23.49	23.4	Manufacture of other ceramic products not elsewhere classified	Gweithgynhyrchu cynhyrchion seramig eraill n.dd.b.		
+23.41	23.4	Manufacture of ceramic household and ornamental articles			
+23.42	23.4	Manufacture of ceramic sanitary fixtures			
+23.43	23.4	Manufacture of ceramic insulators and insulating fittings			
+23.44	23.4	Manufacture of other technical ceramic products			
+23.49	23.4	Manufacture of other ceramic products			
 23.5	23	Manufacture of cement, lime and plaster			
-23.51	23.5	Manufacture of cement	Gweithgynhyrchu sment		
-23.52	23.5	Manufacture of lime and plaster	Gweithgynhyrchu calch a phlastr		
+23.51	23.5	Manufacture of cement			
+23.52	23.5	Manufacture of lime and plaster			
 23.6	23	Manufacture of articles of concrete, cement and plaster			
-23.61	23.6	Manufacture of concrete products for construction purposes	Gweithgynhyrchu cynhyrchion concrit at ddibenion adeiladu		
-23.62	23.6	Manufacture of plaster products for construction purposes	Gweithgynhyrchu cynhyrchion plastr at ddibenion adeiladu		
-23.63	23.6	Manufacture of ready-mixed concrete	Gweithgynhyrchu concrit parod		
-23.64	23.6	Manufacture of mortars	Gweithgynhyrchu morter (priddgalch)		
-23.65	23.6	Manufacture of fibre cement	Gweithgynhyrchu sment ffibr		
-23.69	23.6	Manufacture of other articles of concrete, plaster and cement	Gweithgynhyrchu nwyddau eraill o goncrit, plastr a sment		
+23.61	23.6	Manufacture of concrete products for construction purposes			
+23.62	23.6	Manufacture of plaster products for construction purposes			
+23.63	23.6	Manufacture of ready-mixed concrete			
+23.64	23.6	Manufacture of mortars			
+23.65	23.6	Manufacture of fibre cement			
+23.69	23.6	Manufacture of other articles of concrete, plaster and cement			
 23.7	23	Cutting, shaping and finishing of stone			
-23.70	23.7	Cutting, shaping and finishing of stone	Torri, naddu a gorffennu carreg		
+23.70	23.7	Cutting, shaping and finishing of stone			
 23.9	23	Manufacture of abrasive products and non-metallic mineral products not elsewhere classified			
-23.91	23.9	Production of abrasive products	Cynhyrchu cynhyrchion ffrithiol		
-23.99	23.9	Manufacture of other non-metallic mineral products not elsewhere classified	Gweithgynhyrchu cynhyrchion mwynau anfetelaidd eraill n.dd.b.		
+23.91	23.9	Production of abrasive products			
+23.99	23.9	Manufacture of other non-metallic mineral products not elsewhere classified			
 24	C	Manufacture of basic metals			
 24.1	24	Manufacture of basic iron and steel and of ferro-alloys			
-24.10	24.1	Manufacture of basic iron and steel and of ferro-alloys	Gweithgynhyrchu haearn a dur sylfaenol a ffero-aloeon		
+24.10	24.1	Manufacture of basic iron and steel and of ferro-alloys			
 24.2	24	Manufacture of tubes, pipes, hollow profiles and related fittings, of steel			
-24.20	24.2	Manufacture of tubes, pipes, hollow profiles and related fittings, of steel	Gweithgynhyrchu tiwbiau, pibellau, proffiliau gwag a gosodiadau cysylltiedig, o ddur		
+24.20	24.2	Manufacture of tubes, pipes, hollow profiles and related fittings, of steel			
 24.3	24	Manufacture of other products of first processing of steel			
-24.31	24.3	Cold drawing of bars	Tynnu bariau yn oer		
-24.32	24.3	Cold rolling of narrow strip	Rholio stribedi cul yn oer		
-24.33	24.3	Cold forming or folding	Ffurfio neu blygu oer		
-24.34	24.3	Cold drawing of wire	Tynnu weiar yn oer		
+24.31	24.3	Cold drawing of bars			
+24.32	24.3	Cold rolling of narrow strip			
+24.33	24.3	Cold forming or folding			
+24.34	24.3	Cold drawing of wire			
 24.4	24	Manufacture of basic precious and other non-ferrous metals			
-24.41	24.4	Precious metals production	Cynhyrchu metelau gwerthfawr		
-24.42	24.4	Aluminium production	Cynhyrchu alwminiwm		
-24.43	24.4	Lead, zinc and tin production	Cynhyrchu plwm, sinc a thun		
-24.44	24.4	Copper production	Cynhyrchu copr		
-24.45	24.4	Other non-ferrous metal production	Cynhyrchu metelau anfferrus eraill		
-24.46	24.4	Processing of nuclear fuel	Prosesu tanwydd niwclear		
+24.41	24.4	Precious metals production			
+24.42	24.4	Aluminium production			
+24.43	24.4	Lead, zinc and tin production			
+24.44	24.4	Copper production			
+24.45	24.4	Other non-ferrous metal production			
+24.46	24.4	Processing of nuclear fuel			
 24.5	24	Casting of metals			
-24.51	24.5	Casting of iron	Bwrw haearn		
-24.52	24.5	Casting of steel	Bwrw dur		
-24.53	24.5	Casting of light metals	Bwrw metelau ysgafn		
-24.54	24.5	Casting of other non-ferrous metals	Bwrw metelau anfferrus eraill		
+24.51	24.5	Casting of iron			
+24.52	24.5	Casting of steel			
+24.53	24.5	Casting of light metals			
+24.54	24.5	Casting of other non-ferrous metals			
 25	C	Manufacture of fabricated metal products, except machinery and equipment			
 25.1	25	Manufacture of structural metal products			
-25.11	25.1	Manufacture of metal structures and parts of structures	Gweithgynhyrchu strwythurau metel a rhannau o strwythurau		
-25.12	25.1	Manufacture of doors and windows of metal	Gweithgynhyrchu drysau a ffenestri o fetel		
+25.11	25.1	Manufacture of metal structures and parts of structures			
+25.12	25.1	Manufacture of doors and windows of metal			
 25.2	25	Manufacture of tanks, reservoirs and containers of metal			
-25.21	25.2	Manufacture of central heating radiators and boilers	Gweithgynhyrchu rheiddiaduron a bwyleri gwres canolog		
-25.29	25.2	Manufacture of other tanks, reservoirs and containers of metal	Gweithgynhyrchu tanciau, cronfeydd a chynwysyddion eraill o fetel		
+25.21	25.2	Manufacture of central heating radiators and boilers			
+25.29	25.2	Manufacture of other tanks, reservoirs and containers of metal			
 25.3	25	Manufacture of steam generators, except central heating hot water boilers			
-25.30	25.3	Manufacture of steam generators, except central heating hot water boilers	Gweithgynhyrchu generaduron stêm, ac eithrio bwyleri dŵr poeth gwres canolog		
+25.30	25.3	Manufacture of steam generators, except central heating hot water boilers			
 25.4	25	Manufacture of weapons and ammunition			
-25.40	25.4	Manufacture of weapons and ammunition	Gweithgynhyrchu arfau a ffrwydron rhyfel		
+25.40	25.4	Manufacture of weapons and ammunition			
 25.5	25	Forging, pressing, stamping and roll-forming of metal; powder metallurgy			
-25.50	25.5	Forging, pressing, stamping and roll-forming of metal; powder metallurgy	Gofannu, gwasgu, stampio a rholio metel; meteleg powdr		
+25.50	25.5	Forging, pressing, stamping and roll-forming of metal; powder metallurgy			
 25.6	25	Treatment and coating of metals; machining			
-25.61	25.6	Treatment and coating of metals	Trin a chaenu metelau		
-25.62	25.6	Machining	Turnio		
+25.61	25.6	Treatment and coating of metals			
+25.62	25.6	Machining			
 25.7	25	Manufacture of cutlery, tools and general hardware			
-25.71	25.7	Manufacture of cutlery	Gweithgynhyrchu cytleri		
-25.72	25.7	Manufacture of locks and hinges	Gweithgynhyrchu cloeon a cholfachau		
-25.73	25.7	Manufacture of tools	Gweithgynhyrchu tŵls		
+25.71	25.7	Manufacture of cutlery			
+25.72	25.7	Manufacture of locks and hinges			
+25.73	25.7	Manufacture of tools			
 25.9	25	Manufacture of other fabricated metal products			
-25.91	25.9	Manufacture of steel drums and similar containers	Gweithgynhyrchu drymiau dur a chynwysyddion tebyg		
-25.92	25.9	Manufacture of light metal packaging	Gweithgynhyrchu deunydd pecynnu metel ysgafn		
-25.93	25.9	Manufacture of wire products, chain and springs	Gweithgynhyrchu cynhyrchion weiar, cadwyni a sbringiau		
-25.94	25.9	Manufacture of fasteners and screw machine products	Gweithgynhyrchu ffasnyddion a sgriwiau peiriannol		
-25.99	25.9	Manufacture of other fabricated metal products not elsewhere classified	Gweithgynhyrchu cynhyrchion metel gwneud eraill n.dd.b.		
+25.91	25.9	Manufacture of steel drums and similar containers			
+25.92	25.9	Manufacture of light metal packaging			
+25.93	25.9	Manufacture of wire products, chain and springs			
+25.94	25.9	Manufacture of fasteners and screw machine products			
+25.99	25.9	Manufacture of other fabricated metal products not elsewhere classified			
 26	C	Manufacture of computer, electronic and optical products			
 26.1	26	Manufacture of electronic components and boards			
-26.11	26.1	Manufacture of electronic components	Gweithgynhyrchu cydrannau electronig		
-26.12	26.1	Manufacture of loaded electronic boards	Gweithgynhyrchu byrddau electronig parod		
+26.11	26.1	Manufacture of electronic components			
+26.12	26.1	Manufacture of loaded electronic boards			
 26.2	26	Manufacture of computers and peripheral equipment			
-26.20	26.2	Manufacture of computers and peripheral equipment	Gweithgynhyrchu cyfrifiaduron a pherifferolion		
+26.20	26.2	Manufacture of computers and peripheral equipment			
 26.3	26	Manufacture of communication equipment			
 26.30	26.3	Manufacture of communication equipment			
-26.30/1	26.30	Manufacture of telegraph and telephone apparatus and equipment	Gweithgynhyrchu cyfarpar ac offer telegraff a theleffon		
-26.30/9	26.30	Manufacture of communication equipment other than telegraph, and telephone apparatus and equipment	Gweithgynhyrchu offer a chyfarpar cyfathrebu ac eithrio cyfarpar ac offer telegraff a theleffon		
+26.30/1	26.30	Manufacture of telegraph and telephone apparatus and equipment			
+26.30/9	26.30	Manufacture of communication equipment (other than telegraph and telephone apparatus and equipment)			
 26.4	26	Manufacture of consumer electronics			
-26.40	26.4	Manufacture of consumer electronics	Gweithgynhyrchu electroneg i ddefnyddwyr		
+26.40	26.4	Manufacture of consumer electronics			
 26.5	26	Manufacture of instruments and appliances for measuring, testing and navigation; watches and clocks			
 26.51	26.5	Manufacture of instruments and appliances for measuring, testing and navigation			
-26.51/1	26.51	Manufacture of electronic measuring, testing etc. equipment, not for industrial process control	Gweithgynhyrchu cyfarpar electronig ar gyfer mesur, profi ac ati, ond nid at ddibenion rheoli prosesau diwydiannol		
-26.51/2	26.51	Manufacture of electronic industrial process control equipment	Gweithgynhyrchu cyfarpar electronig i reoli prosesau diwydiannol		
-26.51/3	26.51	Manufacture of non-electronic measuring, testing etc. equipment, not for industrial process control	Gweithgynhyrchu cyfarpar nad yw'n electronig ar gyfer mesur, profi ac ati, ond nid at ddibenion rheoli prosesau diwydiannol		
-26.51/4	26.51	Manufacture of non-electronic industrial process control equipment	Gweithgynhyrchu cyfarpar nad yw'n electronig ar gyfer rheoli prosesau diwydiannol		
-26.52	26.5	Manufacture of watches and clocks	Gweithgynhyrchu watsys a chlociau		
+26.51/1	26.51	Manufacture of electronic instruments and appliances for measuring, testing, and navigation, except industrial process control equipment			
+26.51/2	26.51	Manufacture of electronic industrial process control equipment			
+26.51/3	26.51	Manufacture of non-electronic instruments and appliances for measuring, testing and navigation, except industrial process control equipment			
+26.51/4	26.51	Manufacture of non-electronic industrial process control equipment			
+26.52	26.5	Manufacture of watches and clocks			
 26.6	26	Manufacture of irradiation, electromedical and electrotherapeutic equipment			
-26.60	26.6	Manufacture of irradiation, electromedical and electrotherapeutic equipment	Gweithgynhyrchu cyfarpar arbelydru, electrofeddygol ac electrotherapiwtig		
+26.60	26.6	Manufacture of irradiation, electromedical and electrotherapeutic equipment			
 26.7	26	Manufacture of optical instruments and photographic equipment			
 26.70	26.7	Manufacture of optical instruments and photographic equipment			
-26.70/1	26.70	Manufacture of optical precision instruments	Gweithgynhyrchu cyfarpar manylwaith optig		
-26.70/2	26.70	Manufacture of photographic and cinematographic equipment	Gweithgynhyrchu cyfarpar ffotograffig a sinematograffig		
+26.70/1	26.70	Manufacture of optical precision instruments			
+26.70/2	26.70	Manufacture of photographic and cinematographic equipment			
 26.8	26	Manufacture of magnetic and optical media			
-26.80	26.8	Manufacture of magnetic and optical media	Gweithgynhyrchu cyfryngau magnetig ac optegol		
+26.80	26.8	Manufacture of magnetic and optical media			
 27	C	Manufacture of electrical equipment			
 27.1	27	Manufacture of electric motors, generators, transformers and electricity distribution and control apparatus			
-27.11	27.1	Manufacture of electric motors, generators and transformers	Gweithgynhyrchu moduron trydan, generaduron a newidyddion		
-27.12	27.1	Manufacture of electricity distribution and control apparatus	Gweithgynhyrchu cyfarpar dosbarthu a rheoli trydan		
+27.11	27.1	Manufacture of electric motors, generators and transformers			
+27.12	27.1	Manufacture of electricity distribution and control apparatus			
 27.2	27	Manufacture of batteries and accumulators			
-27.20	27.2	Manufacture of batteries and accumulators	Gweithgynhyrchu batris a chronaduron		
+27.20	27.2	Manufacture of batteries and accumulators			
 27.3	27	Manufacture of wiring and wiring devices			
-27.31	27.3	Manufacture of fibre optic cables	Gweithgynhyrchu ceblau ffibr optig		
-27.32	27.3	Manufacture of other electronic and electric wires and cables	Gweithgynhyrchu gwifrau a cheblau electronig a thrydan eraill		
-27.33	27.3	Manufacture of wiring devices	Gweithgynhyrchu dyfeisiau gwifro		
+27.31	27.3	Manufacture of fibre optic cables			
+27.32	27.3	Manufacture of other electronic and electric wires and cables			
+27.33	27.3	Manufacture of wiring devices			
 27.4	27	Manufacture of electric lighting equipment			
-27.40	27.4	Manufacture of electric lighting equipment	Gweithgynhyrchu offer goleuo trydanol		
+27.40	27.4	Manufacture of electric lighting equipment			
 27.5	27	Manufacture of domestic appliances			
-27.51	27.5	Manufacture of electric domestic appliances	Gweithgynhyrchu dyfeisiau trydan domestig		
-27.52	27.5	Manufacture of non-electric domestic appliances	Gweithgynhyrchu dyfeisiau domestig nad ydynt yn drydanol		
+27.51	27.5	Manufacture of electric domestic appliances			
+27.52	27.5	Manufacture of non-electric domestic appliances			
 27.9	27	Manufacture of other electrical equipment			
-27.90	27.9	Manufacture of other electrical equipment	Gweithgynhyrchu cyfarpar trydanol eraill		
+27.90	27.9	Manufacture of other electrical equipment			
 28	C	Manufacture of machinery and equipment not elsewhere classified			
 28.1	28	Manufacture of general-purpose machinery			
-28.11	28.1	Manufacture of engines and turbines, except aircraft, vehicle and cycle engines	Gweithgynhyrchu injans a thyrbinau, ac eithrio injans awyrennau, cerbydau a beiciau		
-28.12	28.1	Manufacture of fluid power equipment	Gweithgynhyrchu cyfarpar pŵer hylifol		
+28.11	28.1	Manufacture of engines and turbines, except aircraft, vehicle and cycle engines			
+28.12	28.1	Manufacture of fluid power equipment			
 28.13	28.1	Manufacture of other pumps and compressors			
-28.13/1	28.13	Manufacture of pumps	Gweithgynhyrchu pympiau		
-28.13/2	28.13	Manufacture of compressors	Gweithgynhyrchu cywasgyddion		
-28.14	28.1	Manufacture of taps and valves	Gweithgynhyrchu tapiau a falfiau		
-28.15	28.1	Manufacture of bearings, gears, gearing and driving elements	Gweithgynhyrchu berynnau, gerau ac elfennau gerio a gyrru		
+28.13/1	28.13	Manufacture of pumps			
+28.13/2	28.13	Manufacture of compressors			
+28.14	28.1	Manufacture of other taps and valves			
+28.15	28.1	Manufacture of bearings, gears, gearing and driving elements			
 28.2	28	Manufacture of other general-purpose machinery			
-28.21	28.2	Manufacture of ovens, furnaces and furnace burners	Gweithgynhyrchu ffyrnau, ffwrneisi a llosgwyr ffwrnais		
-28.22	28.2	Manufacture of lifting and handling equipment	Gweithgynhyrchu cyfarpar codi a thrin		
-28.23	28.2	Manufacture of office machinery and equipment (except computers and peripheral equipment)	Gweithgynhyrchu peiriannau a chyfarpar swyddfa (ac eithrio cyfrifiaduron a pherifferolion)		
-28.24	28.2	Manufacture of power-driven hand tools	Gweithgynhyrchu tŵls pŵer maint llaw		
-28.25	28.2	Manufacture of non-domestic cooling and ventilation equipment	Gweithgynhyrchu offer oeri ac awyru annomestig		
-28.29	28.2	Manufacture of other general-purpose machinery not elsewhere classified	Gweithgynhyrchu peiriannau eraill at ddibenion cyffredinol n.dd.b.		
+28.21	28.2	Manufacture of ovens, furnaces and furnace burners			
+28.22	28.2	Manufacture of lifting and handling equipment			
+28.23	28.2	Manufacture of office machinery and equipment (except computers and peripheral equipment)			
+28.24	28.2	Manufacture of power-driven hand tools			
+28.25	28.2	Manufacture of non-domestic cooling and ventilation equipment			
+28.29	28.2	Manufacture of other general-purpose machinery not elsewhere classified			
 28.3	28	Manufacture of agricultural and forestry machinery			
 28.30	28.3	Manufacture of agricultural and forestry machinery			
-28.30/1	28.30	Manufacture of agricultural tractors	Gweithgynhyrchu tractorau amaethyddol		
-28.30/2	28.30	Manufacture of agricultural and forestry machinery other than tractors	Gweithgynhyrchu peiriannau amaethyddol a choedwigaeth ac eithrio tractorau		
+28.30/1	28.30	Manufacture of agricultural tractors			
+28.30/2	28.30	Manufacture of agricultural and forestry machinery (other than agricultural tractors)			
 28.4	28	Manufacture of metal forming machinery and machine tools			
-28.41	28.4	Manufacture of metal forming machinery	Gweithgynhyrchu peiriannau ffurfio metel		
-28.49	28.4	Manufacture of other machine tools	Gweithgynhyrchu offer peiriannol eraill		
+28.41	28.4	Manufacture of metal forming machinery			
+28.49	28.4	Manufacture of other machine tools			
 28.9	28	Manufacture of other special-purpose machinery			
-28.91	28.9	Manufacture of machinery for metallurgy	Gweithgynhyrchu peiriannau meteleg		
+28.91	28.9	Manufacture of machinery for metallurgy			
 28.92	28.9	Manufacture of machinery for mining, quarrying and construction			
-28.92/1	28.92	Manufacture of machinery for mining	Gweithgynhyrchu peiriannau mwyngloddio		
-28.92/2	28.92	Manufacture of earthmoving equipment	Gweithgynhyrchu cyfarpar symud tir		
-28.92/3	28.92	Manufacture of equipment for concrete crushing and screening and roadworks	Gweithgynhyrchu cyfarpar malu concrit a sgrinio a gwaith ffyrdd		
-28.93	28.9	Manufacture of machinery for food, beverage and tobacco processing	Gweithgynhyrchu peiriannau prosesu bwyd, diodydd a thybaco		
-28.94	28.9	Manufacture of machinery for textile, apparel and leather production	Gweithgynhyrchu peiriannau cynhyrchu tecstilau, dillad a lledr		
-28.95	28.9	Manufacture of machinery for paper and paperboard production	Gweithgynhyrchu peiriannau cynhyrchu papur a bwrdd papur		
-28.96	28.9	Manufacture of plastics and rubber machinery	Gweithgynhyrchu peiriannau gwneud plastig a rwber		
-28.99	28.9	Manufacture of other special-purpose machinery not elsewhere classified	Gweithgynhyrchu peiriannau pwrpasol eraill n.dd.b.		
+28.92/1	28.92	Manufacture of machinery for mining			
+28.92/2	28.92	Manufacture of earthmoving equipment			
+28.92/3	28.92	Manufacture of equipment for concrete crushing and screening roadworks			
+28.93	28.9	Manufacture of machinery for food, beverage and tobacco processing			
+28.94	28.9	Manufacture of machinery for textile, apparel and leather production			
+28.95	28.9	Manufacture of machinery for paper and paperboard production			
+28.96	28.9	Manufacture of plastics and rubber machinery			
+28.99	28.9	Manufacture of other special-purpose machinery not elsewhere classified			
 29	C	Manufacture of motor vehicles, trailers and semi-trailers			
 29.1	29	Manufacture of motor vehicles			
-29.10	29.1	Manufacture of motor vehicles	Gweithgynhyrchu cerbydau modur		
+29.10	29.1	Manufacture of motor vehicles			
 29.2	29	Manufacture of bodies (coachwork) for motor vehicles; manufacture of trailers and semi-trailers			
 29.20	29.2	Manufacture of bodies (coachwork) for motor vehicles; manufacture of trailers and semi-trailers			
-29.20/1	29.20	Manufacture of bodies (coachwork) for motor vehicles (except caravans)	Gweithgynhyrchu cyrff (coetswaith) cerbydau modur (ac eithrio carafanau)		
-29.20/2	29.20	Manufacture of trailers and semi-trailers	Gweithgynhyrchu trelars a hanner-trelars		
-29.20/3	29.20	Manufacture of caravans	Gweithgynhyrchu carafanau		
+29.20/1	29.20	Manufacture of bodies (coachwork) for motor vehicles (except caravans)			
+29.20/2	29.20	Manufacture of trailers and semi-trailers			
+29.20/3	29.20	Manufacture of caravans			
 29.3	29	Manufacture of parts and accessories for motor vehicles			
-29.31	29.3	Manufacture of electrical and electronic equipment for motor vehicles and their engines	Gweithgynhyrchu cyfarpar trydanol ac electronig ar gyfer cerbydau modur a'u hinjans		
-29.32	29.3	Manufacture of other parts and accessories for motor vehicles	Gweithgynhyrchu darnau ac ategolion eraill ar gyfer cerbydau modur		
+29.31	29.3	Manufacture of electrical and electronic equipment for motor vehicles			
+29.32	29.3	Manufacture of other parts and accessories for motor vehicles			
 30	C	Manufacture of other transport equipment			
 30.1	30	Building of ships and boats			
-30.11	30.1	Building of ships and floating structures	Adeiladu llongau a strwythurau sy'n arnofio		
-30.12	30.1	Building of pleasure and sporting boats	Adeiladu cychod pleser a chwaraeon		
+30.11	30.1	Building of ships and floating structures			
+30.12	30.1	Building of pleasure and sporting boats			
 30.2	30	Manufacture of railway locomotives and rolling stock			
-30.20	30.2	Manufacture of railway locomotives and rolling stock	Gweithgynhyrchu locomotifau a cherbydau rheilffordd		
+30.20	30.2	Manufacture of railway locomotives and rolling stock			
 30.3	30	Manufacture of air and spacecraft and related machinery			
-30.30	30.3	Manufacture of air and spacecraft and related machinery	Gweithgynhyrchu peiriannau awyr a llongau gofod a'r peiriannau cysylltiedig		
+30.30	30.3	Manufacture of air and spacecraft and related machinery			
 30.4	30	Manufacture of military fighting vehicles			
-30.40	30.4	Manufacture of military fighting vehicles	Gweithgynhyrchu cerbydau ymladd milwrol		
+30.40	30.4	Manufacture of military fighting vehicles			
 30.9	30	Manufacture of transport equipment not elsewhere classified			
-30.91	30.9	Manufacture of motorcycles	Gweithgynhyrchu beiciau modur		
-30.92	30.9	Manufacture of bicycles and invalid carriages	Gweithgynhyrchu beiciau a cherbydau i'r methedig		
-30.99	30.9	Manufacture of other transport equipment not elsewhere classified	Gweithgynhyrchu cyfarpar arall ar gyfer trafnidiaeth n.dd.b.		
+30.91	30.9	Manufacture of motorcycles			
+30.92	30.9	Manufacture of bicycles and invalid carriages			
+30.99	30.9	Manufacture of other transport equipment not elsewhere classified			
 31	C	Manufacture of furniture			
 31.0	31	Manufacture of furniture			
-31.01	31.0	Manufacture of office and shop furniture	Gweithgynhyrchu celfi swyddfa a siop		
-31.02	31.0	Manufacture of kitchen furniture	Gweithgynhyrchu celfi'r gegin		
-31.03	31.0	Manufacture of mattresses	Gweithgynhyrchu matresi		
-31.09	31.0	Manufacture of other furniture	Gweithgynhyrchu celfi eraill		
+31.01	31.0	Manufacture of office and shop furniture			
+31.02	31.0	Manufacture of kitchen furniture			
+31.03	31.0	Manufacture of mattresses			
+31.09	31.0	Manufacture of other furniture			
 32	C	Other manufacturing			
 32.1	32	Manufacture of jewellery, bijouterie and related articles			
-32.11	32.1	Striking of coins	Bwrw darnau arian		
-32.12	32.1	Manufacture of jewellery and related articles	Gweithgynhyrchu gemwaith ac eitemau cysylltiedig		
-32.13	32.1	Manufacture of imitation jewellery and related articles	Gweithgynhyrchu gemwaith ffug ac eitemau cysylltiedig		
+32.11	32.1	Striking of coins			
+32.12	32.1	Manufacture of jewellery and related articles			
+32.13	32.1	Manufacture of imitation jewellery and related articles			
 32.2	32	Manufacture of musical instruments			
-32.20	32.2	Manufacture of musical instruments	Gweithgynhyrchu offerynnau cerdd		
+32.20	32.2	Manufacture of musical instruments			
 32.3	32	Manufacture of sports goods			
-32.30	32.3	Manufacture of sports goods	Gweithgynhyrchu nwyddau chwaraeon		
+32.30	32.3	Manufacture of sports goods			
 32.4	32	Manufacture of games and toys			
 32.40	32.4	Manufacture of games and toys			
-32.40/1	32.40	Manufacture of professional and arcade games and toys	Gweithgynhyrchu gemau a theganau proffesiynol ac arcêd		
-32.40/9	32.40	Manufacture of other games and toys, not elsewhere classified	Gweithgynhyrchu gemau a theganau eraill n.dd.b.		
+32.40/1	32.40	Manufacture of professional and arcade games and toys			
+32.40/9	32.40	Manufacture of games and toys (other than professional and arcade games and toys) not elsewhere classified			
 32.5	32	Manufacture of medical and dental instruments and supplies			
-32.50	32.5	Manufacture of medical and dental instruments and supplies	Gweithgynhyrchu offerynnau a nwyddau meddygol a deintyddol		
+32.50	32.5	Manufacture of medical and dental instruments and supplies			
 32.9	32	Other manufacturing not elsewhere classified			
-32.91	32.9	Manufacture of brooms and brushes	Gweithgynhyrchu ysgubellau a brwshys		
-32.99	32.9	Other manufacturing not elsewhere classified	Gweithgynhyrchu arall n.dd.b.		
+32.91	32.9	Manufacture of brooms and brushes			
+32.99	32.9	Other manufacturing not elsewhere classified			
 33	C	Repair and installation of machinery and equipment			
 33.1	33	Repair of fabricated metal products, machinery and equipment			
-33.11	33.1	Repair of fabricated metal products	Atgyweirio cynhyrchion metel gwneuthuredig		
-33.12	33.1	Repair of machinery	Atgyweirio peiriannau		
-33.13	33.1	Repair of electronic and optical equipment	Atgyweirio offer electronig ac optig		
-33.14	33.1	Repair of electrical equipment	Atgyweirio offer trydanol		
-33.15	33.1	Repair and maintenance of ships and boats	Atgyweirio a chynnal llongau a chychod		
-33.16	33.1	Repair and maintenance of aircraft and spacecraft	Atgyweirio a chynnal awyrennau a llongau awyr		
-33.17	33.1	Repair and maintenance of other transport equipment not elsewhere classified	Atgyweirio a chynnal of cyfarpar arall ar gyfer trafnidiaeth n.dd.b.		
-33.19	33.1	Repair of other equipment	Atgyweirio mathau eraill o gyfarpar		
+33.11	33.1	Repair of fabricated metal products			
+33.12	33.1	Repair of machinery			
+33.13	33.1	Repair of electronic and optical equipment			
+33.14	33.1	Repair of electrical equipment			
+33.15	33.1	Repair and maintenance of ships and boats			
+33.16	33.1	Repair and maintenance of aircraft and spacecraft			
+33.17	33.1	Repair and maintenance of other transport equipment			
+33.19	33.1	Repair of other equipment			
 33.2	33	Installation of industrial machinery and equipment			
-33.20	33.2	Installation of industrial machinery and equipment	Gosod peiriannau ac offer diwydiannol		
+33.20	33.2	Installation of industrial machinery and equipment			
 35	D	Electricity, gas, steam and air conditioning supply			
 35.1	35	Electric power generation, transmission and distribution			
-35.11	35.1	Production of electricity	Cynhyrchu trydan		
-35.12	35.1	Transmission of electricity	Trawsyrru trydan		
-35.13	35.1	Distribution of electricity	Dosbarthu trydan		
-35.14	35.1	Trade of electricity	Masnachu trydan		
+35.11	35.1	Production of electricity			
+35.12	35.1	Transmission of electricity			
+35.13	35.1	Distribution of electricity			
+35.14	35.1	Trade of electricity			
 35.2	35	Manufacture of gas; distribution of gaseous fuels through mains			
-35.21	35.2	Manufacture of gas	Gweithgynhyrchu nwy		
-35.22	35.2	Distribution of gaseous fuels through mains	Dosbarthu tanwydd nwyol trwy prif bibell		
-35.23	35.2	Trade of gas through mains	Masnachu nwy trwy prif bibell		
+35.21	35.2	Manufacture of gas			
+35.22	35.2	Distribution of gaseous fuels through mains			
+35.23	35.2	Trade of gas through mains			
 35.3	35	Steam and air conditioning supply			
-35.30	35.3	Steam and air conditioning supply	Cyflenwi stêm a thymherwyr awyr		
+35.30	35.3	Steam and air conditioning supply			
 36	E	Water collection, treatment and supply			
 36.0	36	Water collection, treatment and supply			
-36.00	36.0	Water collection, treatment and supply	Casglu, trin a chyflenwi dŵr		
+36.00	36.0	Water collection, treatment and supply			
 37	E	Sewerage			
 37.0	37	Sewerage			
-37.00	37.0	Sewerage	Carthffosiaeth		
+37.00	37.0	Sewerage			
 38	E	Waste collection, treatment and disposal activities; materials recovery			
 38.1	38	Waste collection			
-38.11	38.1	Collection of non-hazardous waste	Casglu gwastraff nad yw'n beryglus		
-38.12	38.1	Collection of hazardous waste	Casglu gwastraff peryglus		
+38.11	38.1	Collection of non-hazardous waste			
+38.12	38.1	Collection of hazardous waste			
 38.2	38	Waste treatment and disposal			
-38.21	38.2	Treatment and disposal of non-hazardous waste	Trin a gwaredu gwastraff nad yw'n beryglus		
-38.22	38.2	Treatment and disposal of hazardous waste	Trin a gwaredu gwastraff peryglus		
+38.21	38.2	Treatment and disposal of non-hazardous waste			
+38.22	38.2	Treatment and disposal of hazardous waste			
 38.3	38	Materials recovery			
-38.31	38.3	Dismantling of wrecks	Datgymalu drylliadau		
-38.32	38.3	Recovery of sorted materials	Adfer deunyddiau a ddidolwyd		
+38.31	38.3	Dismantling of wrecks			
+38.32	38.3	Recovery of sorted materials			
 39	E	Remediation activities and other waste management services.			
 39.0	39	Remediation activities and other waste management services			
-39.00	39.0	Remediation activities and other waste management services	Gweithgareddau adfer a gwasanaethau rheoli gwastraff eraill		
+39.00	39.0	Remediation activities and other waste management services			
 41	F	Construction of buildings			
 41.1	41	Development of building projects			
-41.10	41.1	Development of building projects	Datblygu projectau adeiladu		
+41.10	41.1	Development of building projects			
 41.2	41	Construction of residential and non-residential buildings			
 41.20	41.2	Construction of residential and non-residential buildings			
-41.20/1	41.20	Construction of commercial buildings	Adeiladu adeiladau masnachol		
-41.20/2	41.20	Construction of domestic buildings	Adeiladu adeiladau domestig		
+41.20/1	41.20	Construction of commercial buildings			
+41.20/2	41.20	Construction of domestic buildings			
 42	F	Civil engineering			
 42.1	42	Construction of roads and railways			
-42.11	42.1	Construction of roads and motorways	Adeiladu ffyrdd a phriffyrdd		
-42.12	42.1	Construction of railways and underground railways	Adeiladu rheilffyrdd a rheilffyrdd tanddaearol		
-42.13	42.1	Construction of bridges and tunnels	Adeiladu pontydd a thwneli		
+42.11	42.1	Construction of roads and motorways			
+42.12	42.1	Construction of railways and underground railways			
+42.13	42.1	Construction of bridges and tunnels			
 42.2	42	Construction of utility projects			
-42.21	42.2	Construction of utility projects for fluids	Adeiladu projectau cyfleustodau hylifau		
-42.22	42.2	Construction of utility projects for electricity and telecommunications	Adeiladu projectau cyfleustodau trydan a thelathrebu		
+42.21	42.2	Construction of utility projects for fluids			
+42.22	42.2	Construction of utility projects for electricity and telecommunications			
 42.9	42	Construction of other civil engineering projects			
-42.91	42.9	Construction of water projects	Adeiladu projectau dŵr		
-42.99	42.9	Construction of other civil engineering projects not elsewhere classified	Adeiladu projectau peirianneg sifil eraill n.dd.b.		
+42.91	42.9	Construction of water projects			
+42.99	42.9	Construction of other civil engineering projects not elsewhere classified			
 43	F	Specialised construction activities			
 43.1	43	Demolition and site preparation			
-43.11	43.1	Demolition	Dymchwel		
-43.12	43.1	Site preparation	Paratoi safleoedd		
-43.13	43.1	Test drilling and boring	Drilio a thorri tyllau profi		
+43.11	43.1	Demolition			
+43.12	43.1	Site preparation			
+43.13	43.1	Test drilling and boring			
 43.2	43	Electrical, plumbing and other construction installation activities			
-43.21	43.2	Electrical installation	Gosod offer trydanol		
-43.22	43.2	Plumbing, heat and air-conditioning installation	Gosod systemau plymio, gwres a thymheru'r aer		
-43.29	43.2	Other construction installation	Mathau eraill osod at ddibenion adeiladu		
+43.21	43.2	Electrical installation			
+43.22	43.2	Plumbing, heat and air-conditioning installation			
+43.29	43.2	Other construction installation			
 43.3	43	Building completion and finishing			
-43.31	43.3	Plastering	Plastro		
-43.32	43.3	Joinery installation	Gosod gwaith coed		
-43.33	43.3	Floor and wall covering	Gorchuddio lloriau a waliau		
+43.31	43.3	Plastering			
+43.32	43.3	Joinery installation			
+43.33	43.3	Floor and wall covering			
 43.34	43.3	Painting and glazing			
-43.34/1	43.34	Painting	Peintio		
-43.34/2	43.34	Glazing	Gwydro		
-43.39	43.3	Other building completion and finishing	Gwaith gorffen a gorffennu adeiladu eraill		
+43.34/1	43.34	Painting			
+43.34/2	43.34	Glazing			
+43.39	43.3	Other building completion and finishing			
 43.9	43	Other specialised construction activities			
-43.91	43.9	Roofing activities	Gweithgareddau gosod to		
+43.91	43.9	Roofing activities			
 43.99	43.9	Other specialised construction activities not elsewhere classified			
-43.99/1	43.99	Scaffold erection	Codi sgaffaldiau		
-43.99/9	43.99	Other specialised construction activities not elsewhere classified	Gweithgareddau adeiladu arbenigol eraill n.dd.b.		
+43.99/1	43.99	Scaffold erection			
+43.99/9	43.99	Specialised construction activities (other than scaffold erection) not elsewhere classified			
 45	G	Wholesale and retail trade and repair of motor vehicles and motorcycles			
 45.1	45	Sale of motor vehicles			
 45.11	45.1	Sale of cars and light motor vehicles			
-45.11/1	45.11	Sale of new cars and light motor vehicles	Gwerthu ceir a cherbydau modur ysgafn newydd		
-45.11/2	45.11	Sale of used cars and light motor vehicles	Gwerthu ceir a cherbydau modur ysgafn ail law		
-45.19	45.1	Sale of other motor vehicles	Gwerthu cerbydau modur eraill		
+45.11/1	45.11	Sale of new cars and light motor vehicles			
+45.11/2	45.11	Sale of used cars and light motor vehicles			
+45.19	45.1	Sale of other motor vehicles			
 45.2	45	Maintenance and repair of motor vehicles			
-45.20	45.2	Maintenance and repair of motor vehicles	Cynnal ac atgyweirio cerbydau modur		
+45.20	45.2	Maintenance and repair of motor vehicles			
 45.3	45	Sale of motor vehicle parts and accessories			
-45.31	45.3	Wholesale trade of motor vehicle parts and accessories	Cyfanwerthu darnau ac ategolion cerbydau modur		
-45.32	45.3	Retail trade of motor vehicle parts and accessories	Adwerthu darnau ac ategolion cerbydau modur		
+45.31	45.3	Wholesale trade of motor vehicle parts and accessories			
+45.32	45.3	Retail trade of motor vehicle parts and accessories			
 45.4	45	Sale, maintenance and repair of motorcycles and related parts and accessories			
-45.40	45.4	Sale, maintenance and repair of motorcycles and related parts and accessories	Gwerthu, cynnal ac atgyweirio beiciau modur a darnau ac ategolion cysylltiedig		
+45.40	45.4	Sale, maintenance and repair of motorcycles and related parts and accessories			
 46	G	Wholesale trade, except of motor vehicles and motorcycles			
 46.1	46	Wholesale on a fee or contract basis			
-46.11	46.1	Agents selling agricultural raw materials, livestock, textile raw materials and semi-finished goods	Asiantau sy'n gwerthu deunydd crai amaethyddol, da byw, deunyddiau crai tecstilau a nwyddau lled-barod		
-46.12	46.1	Agents involved in the sale of fuels, ores, metals and industrial chemicals	Asiantau sydd ynghlwm wrth werthu tanwydd, mwynau, metelau a chemegion diwydiannol		
-46.13	46.1	Agents involved in the sale of timber and building materials	Asiantau sydd ynghlwm wrth werthu pren a deunyddiau adeiladu		
-46.14	46.1	Agents involved in the sale of machinery, industrial equipment, ships and aircraft	Asiantau sydd ynghlwm wrth werthu peiriannau, offer diwydiannol, llongau ac awyrennau		
-46.15	46.1	Agents involved in the sale of furniture, household goods, hardware and ironmongery	Asiantau sydd ynghlwm wrth werthu celfi, nwyddau cartref, caledwedd a nwyddau haearn		
-46.16	46.1	Agents involved in the sale of textiles, clothing, fur, footwear and leather goods	Asiantau sydd ynghlwm wrth werthu tecstilau, dillad, ffwr, esgidiau a nwyddau lledr		
-46.17	46.1	Agents involved in the sale of food, beverages and tobacco	Asiantau sydd ynghlwm wrth werthu bwydydd, diodydd a thybaco		
-46.18	46.1	Agents specialised in the sale of other particular products	Asiantau sy'n arbenigo mewn gwerthu cynhyrchion penodol eraill		
-46.19	46.1	Agents involved in the sale of a variety of goods	Asiantau sydd ynghlwm wrth werthu amrywiaeth o nwyddau		
+46.11	46.1	Agents involved in the sale of agricultural raw materials, live animals, textile raw materials and semi-finished goods			
+46.12	46.1	Agents involved in the sale of fuels, ores, metals and industrial chemicals			
+46.13	46.1	Agents involved in the sale of timber and building materials			
+46.14	46.1	Agents involved in the sale of machinery, industrial equipment, ships and aircraft			
+46.15	46.1	Agents involved in the sale of furniture, household goods, hardware and ironmongery			
+46.16	46.1	Agents involved in the sale of textiles, clothing, fur, footwear and leather goods			
+46.17	46.1	Agents involved in the sale of food, beverages and tobacco			
+46.18	46.1	Agents specialised in the sale of other particular products			
+46.19	46.1	Agents involved in the sale of a variety of goods			
 46.2	46	Wholesale of agricultural raw materials and live animals			
-46.21	46.2	Wholesale of grain, unmanufactured tobacco, seeds and animal feeds	Cyfanwerthu grawn, tybaco crai, hadau a bwydydd anifeiliaid		
-46.22	46.2	Wholesale of flowers and plants	Cyfanwerthu blodau a phlanhigion		
-46.23	46.2	Wholesale of live animals	Cyfanwerthu anifeiliaid byw		
-46.24	46.2	Wholesale of hides, skins and leather	Cyfanwerthu crwyn a lledr		
+46.21	46.2	Wholesale of grain, unmanufactured tobacco, seeds and animal feeds			
+46.22	46.2	Wholesale of flowers and plants			
+46.23	46.2	Wholesale of live animals			
+46.24	46.2	Wholesale of hides, skins and leather			
 46.3	46	Wholesale of food, beverages and tobacco			
-46.31	46.3	Wholesale of fruit and vegetables	Cyfanwerthu ffrwythau a llysiau		
-46.32	46.3	Wholesale of meat and meat products	Cyfanwerthu cig a chynhyrchion cig		
-46.33	46.3	Wholesale of dairy products, eggs and edible oils and fats	Cyfanwerthu cynhyrchion llaeth, wyau ac olewon a brasterau bwytadwy		
+46.31	46.3	Wholesale of fruit and vegetables			
+46.32	46.3	Wholesale of meat and meat products			
+46.33	46.3	Wholesale of dairy products, eggs and edible oils and fats			
 46.34	46.3	Wholesale of beverages			
-46.34/1	46.34	Wholesale of fruit and vegetable juices, mineral water and soft drinks	Cyfanwerthu sudd ffrwythau a llysiau, dŵr mwynol a diodydd ysgafn		
-46.34/2	46.34	Wholesale of wine, beer, spirits and other alcoholic beverages	Cyfanwerthu gwin, cwrw, gwirodydd a diodydd meddwol eraill		
-46.35	46.3	Wholesale of tobacco products	Cyfanwerthu cynhyrchion tybaco		
-46.36	46.3	Wholesale of sugar and chocolate and sugar confectionery	Cyfanwerthu siwgr a siocled a melysion siwgr		
-46.37	46.3	Wholesale of coffee, tea, cocoa and spices	Cyfanwerthu coffi, te, coco a sbeis		
-46.38	46.3	Wholesale of other food, including fish, crustaceans and molluscs	Cyfanwerthu bwydydd eraill, gan gynnwys pysgod, cramenogion a molysgiaid		
-46.39	46.3	Non-specialised wholesale of food, beverages and tobacco	Cyfanwerthu bwydydd, diodydd a thybaco cyffredinol		
+46.34/1	46.34	Wholesale of fruit and vegetable juices, mineral waters and soft drinks			
+46.34/2	46.34	Wholesale of wine, beer, spirits and other alcoholic beverages			
+46.35	46.3	Wholesale of tobacco products			
+46.36	46.3	Wholesale of sugar and chocolate and sugar confectionery			
+46.37	46.3	Wholesale of coffee, tea, cocoa and spices			
+46.38	46.3	Wholesale of other food, including fish, crustaceans and molluscs			
+46.39	46.3	Non-specialised wholesale of food, beverages and tobacco			
 46.4	46	Wholesale of household goods			
-46.41	46.4	Wholesale of textiles	Cyfanwerthu tecstilau		
-46.42	46.4	Wholesale of clothing and footwear	Cyfanwerthu dillad ac esgidiau		
+46.41	46.4	Wholesale of textiles			
+46.42	46.4	Wholesale of clothing and footwear			
 46.43	46.4	Wholesale of electrical household appliances			
-46.43/1	46.43	Wholesale of audio tapes, records, CDs and video tapes and the equipment on which these are played	Cyfanwerthu tapiau sain, recordiau, CDs a thapiau fideo a'r offer ar gyfer eu chwarae		
-46.43/9	46.43	Wholesale of radio, television goods & electrical household appliances (other than records, tapes, CD's & video tapes and the equipment used for playing them)	Cyfanwerthu nwyddau radio a theledu a dyfeisiau trydan i’r cartref (ac eithrio recordiau, tapiau, CDs a thapiau fideo, a’r offer a ddefnyddir i’w chwarae)		
-46.44	46.4	Wholesale of china and glassware and cleaning materials	Cyfanwerthu llestri gwydr a tsieina a deunyddiau glanhau		
-46.45	46.4	Wholesale of perfume and cosmetics	Cyfanwerthu persawr a chosmetigau		
-46.46	46.4	Wholesale of pharmaceutical goods	Cyfanwerthu nwyddau fferyllol		
-46.47	46.4	Wholesale of furniture, carpets and lighting equipment	Cyfanwerthu celfi, carpedi ac offer goleuo		
-46.48	46.4	Wholesale of watches and jewellery	Cyfanwerthu watsys a gemwaith		
+46.43/1	46.43	Wholesale of gramophone records, audio tapes, compact discs and video tapes and of the equipment on which these are played			
+46.43/9	46.43	Wholesale of radio and television goods and of electrical household appliances (other than of gramophone records, audio tapes, compact discs and video tapes and the equipment on which these are played) not elsewhere classified			
+46.44	46.4	Wholesale of china and glassware and cleaning materials			
+46.45	46.4	Wholesale of perfume and cosmetics			
+46.46	46.4	Wholesale of pharmaceutical goods			
+46.47	46.4	Wholesale of furniture, carpets and lighting equipment			
+46.48	46.4	Wholesale of watches and jewellery			
 46.49	46.4	Wholesale of other household goods			
-46.49/1	46.49	Wholesale of musical instruments	Cyfanwerthu offerynnau cerdd		
-46.49/9	46.49	Wholesale of household goods (other than musical instruments) n.e.c	Cyfanwerthu nwyddau cartref (ac eithrio offerynnau cerdd) n.dd.b.		
+46.49/1	46.49	Wholesale of musical instruments			
+46.49/9	46.49	Wholesale of household goods (other than musical instruments) not elsewhere classified			
 46.5	46	Wholesale of information and communication equipment			
-46.51	46.5	Wholesale of computers, computer peripheral equipment and software	Cyfanwerthu cyfrifiaduron, perifferolion cyfrifiadurol a meddalwedd		
-46.52	46.5	Wholesale of electronic and telecommunications equipment and parts	Cyfanwerthu cyfarpar electronig a thelathrebu a'r darnau cysylltiedig		
+46.51	46.5	Wholesale of computers, computer peripheral equipment and software			
+46.52	46.5	Wholesale of electronic and telecommunications equipment and parts			
 46.6	46	Wholesale of other machinery, equipment and supplies			
-46.61	46.6	Wholesale of agricultural machinery, equipment and supplies	Cyfanwerthu peiriannau, cyfarpar a chyflenwadau amaethyddol		
-46.62	46.6	Wholesale of machine tools	Cyfanwerthu offer peiriannol		
-46.63	46.6	Wholesale of mining, construction and civil engineering machinery	Cyfanwerthu peiriannau mwyngloddio, adeiladu a pheirianneg sifil		
-46.64	46.6	Wholesale of machinery for the textile industry and of sewing and knitting machines	Cyfanwerthu peiriannau ar gyfer y diwydiant tecstilau a pheiriannau gwnïo a gwau		
-46.65	46.6	Wholesale of office furniture	Cyfanwerthu celfi swyddfa		
-46.66	46.6	Wholesale of other office machinery and equipment	Cyfanwerthu peiriannau a chyfarpar swyddfa eraill		
-46.69	46.6	Wholesale of other machinery and equipment	Cyfanwerthu peiriannau a chyfarpar eraill		
+46.61	46.6	Wholesale of agricultural machinery, equipment and supplies			
+46.62	46.6	Wholesale of machine tools			
+46.63	46.6	Wholesale of mining, construction and civil engineering machinery			
+46.64	46.6	Wholesale of machinery for the textile industry and of sewing and knitting machines			
+46.65	46.6	Wholesale of office furniture			
+46.66	46.6	Wholesale of other office machinery and equipment			
+46.69	46.6	Wholesale of other machinery and equipment			
 46.7	46	Other specialised wholesale			
 46.71	46.7	Wholesale of solid, liquid and gaseous fuels and related products			
-46.71/1	46.71	Wholesale of petroleum and petroleum products	Cyfanwerthu petrolewm a chynhyrchion petrolewm		
-46.71/9	46.71	Wholesale of other fuels and related products	Cyfanwerthu mathau eraill o danwydd a chynhyrchion cysylltiedig		
-46.72	46.7	Wholesale of metals and metal ores	Cyfanwerthu metelau a mwynau metel		
-46.73	46.7	Wholesale of wood, construction materials and sanitary equipment	Cyfanwerthu pren, deunyddiau adeiladu ac offer iechydol		
-46.74	46.7	Wholesale of hardware, plumbing and heating equipment and supplies	Cyfanwerthu cyfarpar a nwyddau metel, plymio a gwresogi		
-46.75	46.7	Wholesale of chemical products	Cyfanwerthu cynhyrchion cemegol		
-46.76	46.7	Wholesale of other intermediate products	Cyfanwerthu cynhyrchion rhyngol eraill		
-46.77	46.7	Wholesale of waste and scrap	Cyfanwerthu gwastraff a sgrap		
+46.71/1	46.71	Wholesale of petroleum and petroleum products			
+46.71/9	46.71	Wholesale of fuels and related products (other than petroleum and petroleum products)			
+46.72	46.7	Wholesale of metals and metal ores			
+46.73	46.7	Wholesale of wood, construction materials and sanitary equipment			
+46.74	46.7	Wholesale of hardware, plumbing and heating equipment and supplies			
+46.75	46.7	Wholesale of chemical products			
+46.76	46.7	Wholesale of other intermediate products			
+46.77	46.7	Wholesale of waste and scrap			
 46.9	46	Non-specialised wholesale trade			
-46.90	46.9	Non-specialised wholesale trade	Masnach cyfanwerthu cyffredinol		
+46.90	46.9	Non-specialised wholesale trade			
 47	G	Retail trade, except of motor vehicles and motorcycles			
 47.1	47	Retail sale in non-specialised stores			
-47.11	47.1	Retail sale in non-specialised stores with food, beverages or tobacco predominating	Adwerthu mewn siopau cyffredinol sy'n gwerthu bwydydd, diodydd a thybaco yn bennaf		
-47.19	47.1	Other retail sale in non-specialised stores	Adwerthu arall mewn siopau cyffredinol		
+47.11	47.1	Retail sale in non-specialised stores with food, beverages or tobacco predominating			
+47.19	47.1	Other retail sale in non-specialised stores			
 47.2	47	Retail sale of food, beverages and tobacco in specialised stores			
-47.21	47.2	Retail sale of fruit and vegetables in specialised stores	Adwerthu ffrwythau a llysiau mewn siopau arbenigol		
-47.22	47.2	Retail sale of meat and meat products in specialised stores	Adwerthu cig a chynhyrchion cig mewn siopau arbenigol		
-47.23	47.2	Retail sale of fish, crustaceans and molluscs in specialised stores	Adwerthu pysgod, cramenogion a molysgiaid mewn siopau arbenigol		
-47.24	47.2	Retail sale of bread, cakes, flour confectionery and sugar confectionery in specialised stores	Adwerthu bara, cacennau, melysion cannog a melysion siwgr mewn siopau arbenigol		
-47.25	47.2	Retail sale of beverages in specialised stores	Adwerthu diodydd mewn siopau arbenigol		
-47.26	47.2	Retail sale of tobacco products in specialised stores	Adwerthu cynhyrchion tybaco mewn siopau arbenigol		
-47.29	47.2	Other retail sale of food in specialised stores	Adwerthu bwydydd eraill mewn siopau arbenigol		
+47.21	47.2	Retail sale of fruit and vegetables in specialised stores			
+47.22	47.2	Retail sale of meat and meat products in specialised stores			
+47.23	47.2	Retail sale of fish, crustaceans and molluscs in specialised stores			
+47.24	47.2	Retail sale of bread, cakes, flour confectionery and sugar confectionery in specialised stores			
+47.25	47.2	Retail sale of beverages in specialised stores			
+47.26	47.2	Retail sale of tobacco products in specialised stores			
+47.29	47.2	Other retail sale of food in specialised stores			
 47.3	47	Retail sale of automotive fuel in specialised stores			
-47.30	47.3	Retail sale of automotive fuel in specialised stores	Adwerthu tanwydd cerbydau modur mewn siopau arbenigol		
+47.30	47.3	Retail sale of automotive fuel in specialised stores			
 47.4	47	Retail sale of information and communication equipment in specialised stores			
-47.41	47.4	Retail sale of computers, peripheral units and software in specialised stores	Adwerthu cyfrifiaduron, unedau perifferol a meddalwedd mewn siopau arbenigol		
+47.41	47.4	Retail sale of computers, peripheral units and software in specialised stores			
 47.42	47.4	Retail sale of telecommunications equipment in specialised stores			
-47.42/1	47.42	Retail sale of mobile telephones	Adwerthu teleffonau symudol		
-47.42/9	47.42	Retail sale of telecommunications equipment other than mobile telephones	Adwerthu offer telathrebu ac eithrio teleffonau symudol		
-47.43	47.4	Retail sale of audio and video equipment in specialised stores	Adwerthu offer sain a fideo mewn siopau arbenigol		
+47.42/1	47.42	Retail sale of mobile telephones in specialised stores			
+47.42/9	47.42	Retail sale of telecommunications equipment (other than mobile telephones) not elsewhere classified, in specialised stores			
+47.43	47.4	Retail sale of audio and video equipment in specialised stores			
 47.5	47	Retail sale of other household equipment in specialised stores			
-47.51	47.5	Retail sale of textiles in specialised stores	Adwerthu tecstilau mewn siopau arbenigol		
-47.52	47.5	Retail sale of hardware, paints and glass in specialised stores	Adwerthu nwyddau haearn, paent a gwydr mewn siopau arbenigol		
-47.53	47.5	Retail sale of carpets, rugs, wall and floor coverings in specialised stores	Adwerthu carpedi, rygiau, a gorchuddion waliau a lloriau mewn siopau arbenigol		
-47.54	47.5	Retail sale of electrical household appliances in specialised stores	Adwerthu dyfeisiau cartref trydanol mewn siopau arbenigol		
+47.51	47.5	Retail sale of textiles in specialised stores			
+47.52	47.5	Retail sale of hardware, paints and glass in specialised stores			
+47.53	47.5	Retail sale of carpets, rugs, wall and floor coverings in specialised stores			
+47.54	47.5	Retail sale of electrical household appliances in specialised stores			
 47.59	47.5	Retail sale of furniture, lighting equipment and other household articles in specialised stores			
-47.59/1	47.59	Retail sale of musical instruments and scores	Adwerthu offerynnau cerdd a sgoriau		
-47.59/9	47.59	Retail of furniture, lighting, and similar (not musical instruments or scores) in specialised store	Adwerthu celfi, goleuadau a phethau tebyg (nid offerynnau cerdd na sgoriau) mewn siopau arbenigol		
+47.59/1	47.59	Retail sale of musical instruments and scores in specialised stores			
+47.59/9	47.59	Retail sale of furniture, lighting equipment and other household articles (other than musical instruments) not elsewhere classified, in specialised stores			
 47.6	47	Retail sale of cultural and recreation goods in specialised stores			
-47.61	47.6	Retail sale of books in specialised stores	Adwerthu llyfrau mewn siopau arbenigol		
-47.62	47.6	Retail sale of newspapers and stationery in specialised stores	Adwerthu papurau newydd a deunyddiau ysgrifennu mewn siopau arbenigol		
-47.63	47.6	Retail sale of music and video recordings in specialised stores	Adwerthu recordiadau cerddorol a fideo mewn siopau arbenigol		
-47.64	47.6	Retail sale of sports goods, fishing gear, camping goods, boats and bicycles	Adwerthu nwyddau chwaraeon, offer pysgota, offer gwersylla, cychod a beiciau		
-47.65	47.6	Retail sale of games and toys in specialised stores	Adwerthu gemau a theganau mewn siopau arbenigol		
+47.61	47.6	Retail sale of books in specialised stores			
+47.62	47.6	Retail sale of newspapers and stationery in specialised stores			
+47.63	47.6	Retail sale of music and video recordings in specialised stores			
+47.64	47.6	Retail sale of sporting equipment in specialised stores			
+47.65	47.6	Retail sale of games and toys in specialised stores			
 47.7	47	Retail sale of other goods in specialised stores			
-47.71	47.7	Retail sale of clothing in specialised stores	Adwerthu dillad mewn siopau arbenigol		
+47.71	47.7	Retail sale of clothing in specialised stores			
 47.72	47.7	Retail sale of footwear and leather goods in specialised stores			
-47.72/1	47.72	Retail sale of footwear in specialised stores	Adwerthu esgidiau mewn siopau arbenigol		
-47.72/2	47.72	Retail sale of leather goods in specialised stores	Adwerthu nwyddau lledr mewn siopau arbenigol		
-47.73	47.7	Dispensing chemist in specialised stores	Fferyllwyr cymwysedig mewn siop arbenigol		
+47.72/1	47.72	Retail sale of footwear in specialised stores			
+47.72/2	47.72	Retail sale of leather goods in specialised stores			
+47.73	47.7	Dispensing chemist in specialised stores			
 47.74	47.7	Retail sale of medical and orthopaedic goods in specialised stores			
-47.74/1	47.74	Retail sale of hearing aids	Adwerthu cymhorthion clyw		
-47.74/9	47.74	Retail sale of medical and orthopaedic goods in specialised stores (not incl. hearing aids) not elsewhere classified	Adwerthu nwyddau meddygol ac orthopaedig  mewn siopau arbenigol (ac eithrio cymhorthion clyw) n.dd.b.		
-47.75	47.7	Retail sale of cosmetic and toilet articles in specialised stores	Adwerthu nwyddau cosmetig ac ymolchi mewn siopau arbenigol		
-47.76	47.7	Retail sale of flowers, plants, seeds, fertilizers, pet animals and pet food in specialised stores	Adwerthu blodau, planhigion, hadau, gwrtaith, anifeiliaid anwes a bwyd anifeiliaid anwes mewn siopau arbenigol		
-47.77	47.7	Retail sale of watches and jewellery in specialised stores	Adwerthu watsys a gemwaith mewn siopau arbenigol		
+47.74/1	47.74	Retail sale of hearing aids in specialised stores			
+47.74/9	47.74	Retail sale of medical and orthopaedic goods (other than hearing aids) not elsewhere classified, in specialised stores			
+47.75	47.7	Retail sale of cosmetic and toilet articles in specialised stores			
+47.76	47.7	Retail sale of flowers, plants, seeds, fertilisers, pet animals and pet food in specialised stores			
+47.77	47.7	Retail sale of watches and jewellery in specialised stores			
 47.78	47.7	Other retail sale of new goods in specialised stores			
-47.78/1	47.78	Retail sale in commercial art galleries	Adwerthu mewn orielau celf masnachol		
-47.78/2	47.78	Retail sale by opticians	Adwerthu gan optegwyr		
-47.78/9	47.78	Other retail sale of new goods in specialised stores (not commercial art galleries and opticians)	Adwerthu nwyddau newydd eraill mewn siopau arbenigol (nid orielau celf masnachol nac optegwyr)		
+47.78/1	47.78	Retail sale in commercial art galleries			
+47.78/2	47.78	Retail sale by opticians			
+47.78/9	47.78	Other retail sale of new goods in specialised stores (other than by opticians or commercial art galleries), n.e.c			
 47.79	47.7	Retail sale of second-hand goods in stores			
-47.79/1	47.79	Retail sale of antiques including antique books in stores	Adwerthu hen greiriau gan gynnwys hen lyfrau mewn siopau		
-47.79/9	47.79	Retail sale of other second-hand goods in stores (not incl. antiques)	Adwerthu nwyddau ail-law eraill mewn siopau (ac eithrio hen greiriau)		
+47.79/1	47.79	Retail sale of antiques including antique books, in stores			
+47.79/9	47.79	Retail sale of second-hand goods (other than antiques and antique books) in stores			
 47.8	47	Retail sale via stalls and markets			
-47.81	47.8	Retail sale via stalls and markets of food, beverages and tobacco products	Adwerthu bwydydd, diodydd a chynhyrchion tybaco o stondinau a thrwy farchnadoedd		
-47.82	47.8	Retail sale via stalls and markets of textiles, clothing and footwear	Adwerthu tecstilau, dillad ac esgidiau o stondinau a thrwy farchnadoedd		
-47.89	47.8	Retail sale via stalls and markets of other goods	Adwerthu nwyddau eraill o stondinau a thrwy farchnadoedd		
+47.81	47.8	Retail sale via stalls and markets of food, beverages and tobacco products			
+47.82	47.8	Retail sale via stalls and markets of textiles, clothing and footwear			
+47.89	47.8	Retail sale via stalls and markets of other goods			
 47.9	47	Retail trade not in stores, stalls or markets			
-47.91	47.9	Retail sale via mail order houses or via Internet	Adwerthu trwy'r post neu dros y Rhyngrwyd		
-47.99	47.9	Other retail sale not in stores, stalls or markets	Adwerthu arall heb fod mewn siopau, o stondinau neu drwy farchnadoedd		
+47.91	47.9	Retail sale via mail order houses or via Internet			
+47.99	47.9	Other retail sale not in stores, stalls or markets			
 49	H	Land transport and transport via pipelines			
 49.1	49	Passenger rail transport, interurban			
-49.10	49.1	Passenger rail transport, interurban	Cludo teithwyr ar y rheilffordd, rhyngdrefol		
+49.10	49.1	Passenger rail transport, interurban			
 49.2	49	Freight rail transport			
-49.20	49.2	Freight rail transport	Cludo nwyddau ar y rheilffordd		
+49.20	49.2	Freight rail transport			
 49.3	49	Other passenger land transport			
 49.31	49.3	Urban and suburban passenger land transport			
-49.31/1	49.31	Urban and suburban passenger railway transportation by underground, metro and similar systems	Cludo teithwyr trefol a maestrefol ar systemau rheilffyrdd tanddaearol, metro a systemau tebyg		
-49.31/9	49.31	Other urban, suburban or metropolitan passenger land transport (not underground, metro or similar)	Cludo teithwyr trefol, maestrefol neu ddinesig dros y tir (nid systemau tanddaearol, metro na'u tebyg)		
-49.32	49.3	Taxi operation	Busnes tacsi		
-49.39	49.3	Other passenger land transport	Dulliau eraill o gludo teithwyr ar y tir		
+49.31/1	49.31	Urban, suburban or metropolitan area passenger railway transportation by underground, metro and similar systems			
+49.31/9	49.31	Urban, suburban or metropolitan area passenger land transport other than railway transportation by underground, metro and similar systems			
+49.32	49.3	Taxi operation			
+49.39	49.3	Other passenger land transport not elsewhere classified			
 49.4	49	Freight transport by road and removal services			
-49.41	49.4	Freight transport by road	Cludo nwyddau ar y ffyrdd		
-49.42	49.4	Removal services	Gwasanaethau mudo		
+49.41	49.4	Freight transport by road			
+49.42	49.4	Removal services			
 49.5	49	Transport via pipeline			
-49.50	49.5	Transport via pipeline	Trafnidiaeth trwy lein beipiau		
+49.50	49.5	Transport via pipeline			
 50	H	Water transport			
 50.1	50	Sea and coastal passenger water transport			
-50.10	50.1	Sea and coastal passenger water transport	Cludo teithwyr ar ddyfroedd morol ac arfordirol		
+50.10	50.1	Sea and coastal passenger water transport			
 50.2	50	Sea and coastal freight water transport			
-50.20	50.2	Sea and coastal freight water transport	Cludo nwyddau ar ddyfroedd morol ac arfordirol		
+50.20	50.2	Sea and coastal freight water transport			
 50.3	50	Inland passenger water transport			
-50.30	50.3	Inland passenger water transport	Cludo teithwyr ar ddyfroedd mewndirol		
+50.30	50.3	Inland passenger water transport			
 50.4	50	Inland freight water transport			
-50.40	50.4	Inland freight water transport	Cludo nwyddau ar ddyfroedd mewndirol		
+50.40	50.4	Inland freight water transport			
 51	H	Air transport			
 51.1	51	Passenger air transport			
 51.10	51.1	Passenger air transport			
-51.10/1	51.10	Scheduled passenger air transport	Trafnidiaeth a raglennir ar gyfer teithwyr awyr		
-51.10/2	51.10	Non-scheduled passenger air transport	Trafnidiaeth na raglennir ar gyfer teithwyr awyr		
+51.10/1	51.10	Scheduled passenger air transport			
+51.10/2	51.10	Non-scheduled passenger air transport			
 51.2	51	Freight air transport and space transport			
-51.21	51.2	Freight air transport	Trafnidiaeth awyr ar gyfer nwyddau		
-51.22	51.2	Space transport	Trafnidiaeth y gofod		
+51.21	51.2	Freight air transport			
+51.22	51.2	Space transport			
 52	H	Warehousing and support activities for transportation			
 52.1	52	Warehousing and storage			
 52.10	52.1	Warehousing and storage			
-52.10/1	52.10	Operation of warehousing and storage facilities for water transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo ar y dŵr		
-52.10/2	52.10	Operation of warehousing and storage facilities for air transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo yn yr awyr		
-52.10/3	52.10	Operation of warehousing and storage facilities for land transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo ar y tir		
+52.10/1	52.10	Operation of warehousing and storage facilities for water transport activities of division 50			
+52.10/2	52.10	Operation of warehousing and storage facilities for air transport activities of division 51			
+52.10/3	52.10	Operation of warehousing and storage facilities for land transport activities of division 49			
 52.2	52	Support activities for transportation			
 52.21	52.2	Service activities incidental to land transportation			
-52.21/1	52.21	Operation of rail freight terminals	Gweithredu terfynellau cludo nwyddau ar y rheilffyrdd		
-52.21/2	52.21	Operation of rail passenger facilities at railway stations	Gweithredu cyfleusterau ar gyfer teithwyr mewn gorsafoedd rheilffordd		
-52.21/3	52.21	Operation of bus and coach passenger facilities at bus and coach stations	Gweithredu cyfleusterau ar gyfer teithwyr mewn gorsafoedd bysiau a choetsys		
-52.21/9	52.21	Other service activities incidental to land transportation, not elsewhere classified	Gwasanaethau eraill sydd ynghlwm wrth drafnidiaeth dros y tir, n.dd.b.		
-52.22	52.2	Service activities incidental to water transportation	Gwasanaethau sydd ynghlwm wrth drafnidiaeth ar y dŵr		
-52.23	52.2	Service activities incidental to air transportation	Gwasanaethau sydd ynghlwm wrth drafnidiaeth awyr		
+52.21/1	52.21	Operation of rail freight terminals			
+52.21/2	52.21	Operation of rail passenger facilities at railway stations			
+52.21/3	52.21	Operation of bus and coach passenger facilities at bus and coach stations			
+52.21/9	52.21	Other service activities incidental to land transportation, not elsewhere classified (not including operation of rail freight terminals, passenger facilities at railway stations or passenger facilities at bus and coach stations)			
+52.22	52.2	Service activities incidental to water transportation			
+52.23	52.2	Service activities incidental to air transportation			
 52.24	52.2	Cargo handling			
-52.24/1	52.24	Cargo handling for water transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth ar y dŵr		
-52.24/2	52.24	Cargo handling for air transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth awyr		
-52.24/3	52.24	Cargo handling for land transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth dros y tir		
-52.29	52.2	Other transportation support activities	Gweithgareddau eraill sy'n ategu trafnidiaeth		
+52.24/1	52.24	Cargo handling for water transport activities of division 50			
+52.24/2	52.24	Cargo handling for air transport activities of division 51			
+52.24/3	52.24	Cargo handling for land transport activities of division 49			
+52.29	52.2	Other transportation support activities			
 53	H	Postal and courier activities			
 53.1	53	Postal activities under universal service obligation			
-53.10	53.1	Postal activities under universal service obligation	Gweithgareddau post o dan rhwymedigaeth gwasanaeth gyffredinol		
+53.10	53.1	Postal activities under universal service obligation			
 53.2	53	Other postal and courier activities			
 53.20	53.2	Other postal and courier activities			
-53.20/1	53.20	Licensed carriers	Cludwr trwyddedig		
-53.20/2	53.20	Unlicensed carriers	Cludwr didrwydded		
+53.20/1	53.20	Licensed Carriers			
+53.20/2	53.20	Unlicensed Carriers			
 55	I	Accommodation			
 55.1	55	Hotels and similar accommodation			
-55.10	55.1	Hotels and similar accommodation	Gwestai a llety tebyg		
+55.10	55.1	Hotels and similar accommodation			
 55.2	55	Holiday and other short-stay accommodation			
 55.20	55.2	Holiday and other short-stay accommodation			
-55.20/1	55.20	Holiday centres and villages	Canolfannau a phentrefi gwyliau		
-55.20/2	55.20	Youth hostels	Hostelau ieuenctid		
-55.20/9	55.20	Other holiday and other collective accommodation	Llety gwyliau arall a mathau eraill o lety torfol		
+55.20/1	55.20	Holiday centres and villages			
+55.20/2	55.20	Youth hostels			
+55.20/9	55.20	Other holiday and other short-stay accommodation (not including holiday centres and villages or youth hostels) not elsewhere classified			
 55.3	55	Camping grounds, recreational vehicle parks and trailer parks			
-55.30	55.3	Recreational vehicle parks, trailer parks and camping grounds	Parciau cerbydau hamdden, parciau trelars a meysydd gwersylla		
+55.30	55.3	Camping grounds, recreational vehicle parks and trailer parks			
 55.9	55	Other accommodation			
-55.90	55.9	Other accommodation	Llety arall		
+55.90	55.9	Other accommodation			
 56	I	Food and beverage service activities			
 56.1	56	Restaurants and mobile food service activities			
 56.10	56.1	Restaurants and mobile food service activities			
-56.10/1	56.10	Licenced restaurants	Tai bwyta trwyddedig		
-56.10/2	56.10	Unlicenced restaurants and cafes	Tai bwyta a chaffis didrwydded		
-56.10/3	56.10	Take-away food shops and mobile food stands	Siopau prydau parod a stondinau bwyd symudol		
+56.10/1	56.10	Licensed restaurants			
+56.10/2	56.10	Unlicensed restaurants and cafes			
+56.10/3	56.10	Take away food shops and mobile food stands			
 56.2	56	Event catering and other food service activities			
-56.21	56.2	Event catering activities	Gweithgareddau arlwyo ar gyfer digwyddiadau		
-56.29	56.2	Other food services	Gwasanaethau bwyd eraill		
+56.21	56.2	Event catering activities			
+56.29	56.2	Other food service activities			
 56.3	56	Beverage serving activities			
 56.30	56.3	Beverage serving activities			
-56.30/1	56.30	Licenced clubs	Clybiau trwyddedig		
-56.30/2	56.30	Public houses and bars	Tafarndai  a bariau		
+56.30/1	56.30	Licensed clubs			
+56.30/2	56.30	Public houses and bars			
 58	J	Publishing activities			
 58.1	58	Publishing of books, periodicals and other publishing activities			
-58.11	58.1	Book publishing	Cyhoeddi llyfrau		
-58.12	58.1	Publishing of directories and mailing lists	Cyhoeddi cyfeirlyfrau a rhestrau postio		
-58.13	58.1	Publishing of newspapers	Cyhoeddi papurau newydd		
+58.11	58.1	Book publishing			
+58.12	58.1	Publishing of directories and mailing lists			
+58.13	58.1	Publishing of newspapers			
 58.14	58.1	Publishing of journals and periodicals			
-58.14/1	58.14	Publishing of learned journals	Cyhoeddi cyfnodolion dysgedig		
-58.14/2	58.14	Publishing of  consumer and business journals and periodicals	Cyhoeddi cyfnodolion a newyddiaduron i ddefnyddwyr a busnesau		
-58.19	58.1	Other publishing activities	Gweithgareddau cyhoeddi eraill		
+58.14/1	58.14	Publishing of learned journals			
+58.14/2	58.14	Publishing of consumer, business and professional journals and periodicals			
+58.19	58.1	Other publishing activities			
 58.2	58	Software publishing			
-58.21	58.2	Publishing of computer games	Cyhoeddi gemau cyfrifiadur		
-58.29	58.2	Other software publishing	Cyhoeddi meddalwedd arall		
+58.21	58.2	Publishing of computer games			
+58.29	58.2	Other software publishing			
 59	J	Motion picture, video and television programme production, sound recording and music publishing activities			
 59.1	59	Motion picture, video and television programme activities			
 59.11	59.1	Motion picture, video and television programme production activities			
-59.11/1	59.11	Motion picture production activities	Gweithgareddau cynhyrchu ffilmiau		
-59.11/2	59.11	Video production activities	Gweithgareddau cynhyrchu fideo		
-59.11/3	59.11	Television programme production activities	Gweithgareddau cynhyrchu rhaglenni teledu		
-59.12	59.1	Motion picture, video and television programme post-production activities	Gweithgareddau ôl-gynhyrchu ar gyfer ffilmiau, fideo a rhaglenni teledu		
+59.11/1	59.11	Motion picture production activities			
+59.11/2	59.11	Video production activities			
+59.11/3	59.11	Television programme production activities			
+59.12	59.1	Motion picture, video and television programme post-production activities			
 59.13	59.1	Motion picture, video and television programme distribution activities			
-59.13/1	59.13	Motion picture distribution activities	Gweithgareddau dosbarthu ffilmiau		
-59.13/2	59.13	Video distribution activities	Gweithgareddau dosbarthu fideo		
-59.13/3	59.13	Television programme distribution activities	Gweithgareddau dosbarthu rhaglenni teledu		
-59.14	59.1	Motion picture projection activities	Gweithgareddau taflunio ffilmiau		
+59.13/1	59.13	Motion picture distribution activities			
+59.13/2	59.13	Video distribution activities			
+59.13/3	59.13	Television programme distribution activities			
+59.14	59.1	Motion picture projection activities			
 59.2	59	Sound recording and music publishing activities			
-59.20	59.2	Sound recording and music publishing activities	Gweithgareddau recordio sain a chyhoeddi cerddoriaeth		
+59.20	59.2	Sound recording and music publishing activities			
 60	J	Programming and broadcasting activities			
 60.1	60	Radio broadcasting			
-60.10	60.1	Radio broadcasting	Darlledu ar y radio		
+60.10	60.1	Radio broadcasting			
 60.2	60	Television programming and broadcasting activities			
-60.20	60.2	Television programming and broadcasting activities	Gweithgareddau rhaglennu a darlledu ar y teledu		
+60.20	60.2	Television programming and broadcasting activities			
 61	J	Telecommunications			
 61.1	61	Wired telecommunications activities			
-61.10	61.1	Wired telecommunications activities	Gweithgareddau telathrebu â gwifrau		
+61.10	61.1	Wired telecommunications activities			
 61.2	61	Wireless telecommunications activities			
-61.20	61.2	Wireless telecommunications activities	Gweithgareddau telathrebu diwifr		
+61.20	61.2	Wireless telecommunications activities			
 61.3	61	Satellite telecommunications activities			
-61.30	61.3	Satellite telecommunications activities	Gweithgareddau telathrebu drwy loeren		
+61.30	61.3	Satellite telecommunications activities			
 61.9	61	Other telecommunications activities			
-61.90	61.9	Other telecommunications activities	Gweithgareddau telathrebu eraill		
+61.90	61.9	Other telecommunications activities			
 62	J	Computer programming, consultancy and related activities			
 62.0	62	Computer programming, consultancy and related activities			
 62.01	62.0	Computer programming activities			
-62.01/1	62.01	Ready-made interactive leisure and entertainment software development	Datblygu meddalwedd hamdden ac adloniant ryngweithiol barod		
-62.01/2	62.01	Business and domestic software development	Datblygu meddalwedd busnes a domestig		
-62.02	62.0	Information technology consultancy activities	Gweithgareddau ymgynghoriaeth ym maes technoleg gwybodaeth		
-62.03	62.0	Computer facilities management activities	Gweithgareddau rheoli cyfleusterau cyfrifiadurol		
-62.09	62.0	Other information technology service activities	Gweithgareddau eraill ym maes gwasanaethau technoleg gwybodaeth		
+62.01/1	62.01	Ready-made interactive leisure and entertainment software development			
+62.01/2	62.01	Business and domestic software development			
+62.02	62.0	Computer consultancy activities			
+62.03	62.0	Computer facilities management activities			
+62.09	62.0	Other information technology and computer service activities			
 63	J	Information service activities			
 63.1	63	Data processing, hosting and related activities; web portals			
-63.11	63.1	Data processing, hosting and related activities	Prosesu a lletya data a gweithgareddau cysylltiedig		
-63.12	63.1	Web portals	Pyrth ar y we		
+63.11	63.1	Data processing, hosting and related activities			
+63.12	63.1	Web portals			
 63.9	63	Other information service activities			
-63.91	63.9	News agency activities	Gweithgareddau asiantaethau newyddion		
-63.99	63.9	Other information service activities not elsewhere classified	Gweithgareddau gwasanaethau gwybodaeth eraill n.dd.b.		
+63.91	63.9	News agency activities			
+63.99	63.9	Other information service activities not elsewhere classified			
 64	K	Financial service activities, except insurance and pension funding			
 64.1	64	Monetary intermediation			
-64.11	64.1	Central banking	Bancio canolog		
+64.11	64.1	Central banking			
 64.19	64.1	Other monetary intermediation			
-64.19/1	64.19	Banks	Banciau		
-64.19/2	64.19	Building societies	Cymdeithasau adeiladu		
+64.19/1	64.19	Banks			
+64.19/2	64.19	Building societies			
 64.2	64	Activities of holding companies			
 64.20	64.2	Activities of holding companies			
-64.20/1	64.20	Activities of agricultural holding companies	Gweithgareddau cwmnïau daliannol ym maes amaeth		
-64.20/2	64.20	Activities of production holding companies	Gweithgareddau cwmnïau daliannol ym maes cynhyrchu		
-64.20/3	64.20	Activities of construction holding companies	Gweithgareddau cwmnïau daliannol ym maes adeiladu		
-64.20/4	64.20	Activities of distribution holding companies	Gweithgareddau cwmnïau daliannol ym maes dosbarthu		
-64.20/5	64.20	Activities of financial services holding companies	Gweithgareddau cwmnïau daliannol ym maes gwasanaethau ariannol		
-64.20/9	64.20	Activities of other holding companies not elsewhere classified	Gweithgareddau cwmnïau daliannol eraill n.dd.b.		
+64.20/1	64.20	Activities of agricultural holding companies			
+64.20/2	64.20	Activities of production holding companies			
+64.20/3	64.20	Activities of construction holding companies			
+64.20/4	64.20	Activities of distribution holding companies			
+64.20/5	64.20	Activities of financial services holding companies			
+64.20/9	64.20	Activities of other holding companies (not including agricultural, production, construction, distribution and financial services holding companies) not elsewhere classified			
 64.3	64	Trusts, funds and similar financial entities			
 64.30	64.3	Trusts, funds and similar financial entities			
-64.30/1	64.30	Activities of investment trusts	Gweithgareddau ymddiriedolaethau buddsoddi		
-64.30/2	64.30	Activities of unit trusts	Gweithgareddau ymddiriedolaethau unedol		
-64.30/3	64.30	Activities of venture and development capital companies	Gweithgareddau cwmnïau cyfalaf mentro a datblygu		
-64.30/4	64.30	Activities of open-ended investment companies	Gweithgareddau cwmnïau buddsoddi penagored		
-64.30/5	64.30	Activities of property unit trusts	Gweithgareddau ymddiriedolaethau eiddo unedol		
-64.30/6	64.30	Activities of real estate investment trusts	Gweithgareddau ymddiriedolaethau buddsoddi mewn eiddo diriaethol		
+64.30/1	64.30	Activities of investment trusts			
+64.30/2	64.30	Activities of unit trusts			
+64.30/3	64.30	Activities of venture and development capital companies			
+64.30/4	64.30	Activities of open-ended investment companies			
+64.30/5	64.30	Activities of property unit trusts			
+64.30/6	64.30	Activities of real estate investment trusts			
 64.9	64	Other financial service activities, except insurance and pension funding			
-64.91	64.9	Financial leasing	Prydlesu ariannol		
+64.91	64.9	Financial leasing			
 64.92	64.9	Other credit granting			
-64.92/1	64.92	Credit granting by non-deposit taking finance houses and other specialist consumer credit grantors	Ariandai sy'n rhoi credyd nad ydynt yn cymryd adnau a darparwyr credyd arbenigol eraill i ddefnyddwyr		
-64.92/2	64.92	Activities of mortgage finance companies	Gweithgareddau cwmnïau ariannu morgeisi		
-64.92/9	64.92	Other credit granting not elsewhere classified	Darparwyr credyd eraill n.dd.b.		
+64.92/1	64.92	Credit granting by non-deposit taking finance houses and other specialist consumer credit grantors			
+64.92/2	64.92	Activities of mortgage finance companies			
+64.92/9	64.92	Other credit granting (not including credit granting by non-deposit taking finance houses and other specialist consumer credit grantors and activities of mortgage finance companies) not elsewhere classified			
 64.99	64.9	Other financial service activities, except insurance and pension funding, not elsewhere classified			
-64.99/1	64.99	Security dealing on own account	Gwerthu gwarannau ar ei gyfrif ei hun		
-64.99/2	64.99	Factoring	Asiantau masnachol		
-64.99/9	64.99	Financial intermediation not elsewhere classified	Mathau eraill o ryngoli ariannol na ddosbarthwyd fel arall		
+64.99/1	64.99	Security dealing on own account			
+64.99/2	64.99	Factoring			
+64.99/9	64.99	Other financial service activities, except insurance and pension funding, (not including security dealing on own account and factoring) not elsewhere classified			
 65	K	Insurance, reinsurance and pension funding, except compulsory social security			
 65.1	65	Insurance			
-65.11	65.1	Life insurance	Yswiriant bywyd		
-65.12	65.1	Non-life insurance	Yswiriant nad yw'n yswiriant bywyd		
+65.11	65.1	Life insurance			
+65.12	65.1	Non-life insurance			
 65.2	65	Reinsurance			
 65.20	65.2	Reinsurance			
-65.20/1	65.20	Life reinsurance	Ailyswirio bywydau		
-65.20/2	65.20	Non-life reinsurance	Ailyswirio pethau heblaw bywyd		
+65.20/1	65.20	Life reinsurance			
+65.20/2	65.20	Non-life reinsurance			
 65.3	65	Pension funding			
-65.30	65.3	Pension funding	Ariannu pensiynau		
+65.30	65.3	Pension funding			
 66	K	Activities auxiliary to financial services and insurance activities			
 66.1	66	Activities auxiliary to financial services, except insurance and pension funding			
-66.11	66.1	Administration of financial markets	Gweinyddu marchnadoedd ariannol		
-66.12	66.1	Security and commodity contracts dealing activities	Gweithgareddau masnachu contractau nwyddau a gwarannau		
-66.19	66.1	Activities auxiliary to financial intermediation not elsewhere classified	Gweithgareddau atodol o ran rhyngoli ariannol n.dd.b.		
+66.11	66.1	Administration of financial markets			
+66.12	66.1	Security and commodity contracts brokerage			
+66.19	66.1	Other activities auxiliary to financial services, except insurance and pension funding			
 66.2	66	Activities auxiliary to insurance and pension funding			
-66.21	66.2	Risk and damage evaluation	Gwerthuso risg a difrod		
-66.22	66.2	Activities of insurance agents and brokers	Gweithgareddau asiantau a broceriaid yswiriant		
-66.29	66.2	Other activities auxiliary to insurance and pension funding	Gweithgareddau atodol eraill ym maes ariannu yswiriant a phensiynau		
+66.21	66.2	Risk and damage evaluation			
+66.22	66.2	Activities of insurance agents and brokers			
+66.29	66.2	Other activities auxiliary to insurance and pension funding			
 66.3	66	Fund management activities			
-66.30	66.3	Fund management activities	Gweithgareddau rheoli cronfeydd		
+66.30	66.3	Fund management activities			
 68	L	Real estate activities			
 68.1	68	Buying and selling of own real estate			
-68.10	68.1	Buying and selling of own real estate	Prynu a gwerthu eich eiddo diriaethol eich hun		
+68.10	68.1	Buying and selling of own real estate			
 68.2	68	Renting and operating of own or leased real estate			
 68.20	68.2	Renting and operating of own or leased real estate			
-68.20/1	68.20	Renting and operating of Housing Association real estate	Rhentu a rheoli eiddo diriaethol Cymdeithas Tai		
-68.20/2	68.20	Letting and operating of conference and exhibition centres	Gosod a rheoli canolfannau cynadledda ac arddangos		
-68.20/9	68.20	Other letting and operating of own or leased real estate	Gosod a rheoli eich eiddo diriaethol arall eich hun neu ar brydles		
+68.20/1	68.20	Renting and operating of Housing Association real estate			
+68.20/2	68.20	Letting and operating of conference and exhibition centres			
+68.20/9	68.20	Letting and operating of own or leased real estate (other than Housing Association real estate and conference and exhibition services) not elsewhere classified			
 68.3	68	Real estate activities on a fee or contract basis			
-68.31	68.3	Real estate agencies	Asiantaethau eiddo diriaethol		
-68.32	68.3	Management of real estate on a fee or contract basis	Rheoli eiddo diriaethol am ffi neu ar gontract		
+68.31	68.3	Real estate agencies			
+68.32	68.3	Management of real estate on a fee or contract basis			
 69	M	Legal and accounting activities			
 69.1	69	Legal activities			
 69.10	69.1	Legal activities			
-69.10/1	69.10	Barristers at law	Bargyfreithwyr sy'n ymarfer y gyfraith		
-69.10/2	69.10	Solicitors	Cyfreithwyr		
-69.10/9	69.10	Activities of patent and copyright agents; other legal activities not elsewhere classified	Gweithgareddau asiantau patent a hawlfraint; gweithgareddau cyfreithiol eraill n.dd.b.		
+69.10/1	69.10	Barristers at law			
+69.10/2	69.10	Solicitors			
+69.10/9	69.10	Activities of patent and copyright agents; other legal activities (other than those of barristers and solicitors) not elsewhere classified			
 69.2	69	Accounting, bookkeeping and auditing activities; tax consultancy			
 69.20	69.2	Accounting, bookkeeping and auditing activities; tax consultancy			
-69.20/1	69.20	Accounting and auditing activities	Gweithgareddau cyfrifyddu ac archwilio		
-69.20/2	69.20	Bookkeeping activities	Gweithgareddau cadw cyfrifon		
-69.20/3	69.20	Tax consultancy	Ymgynghoriaeth ar drethi		
+69.20/1	69.20	Accounting, and auditing activities			
+69.20/2	69.20	Bookkeeping activities			
+69.20/3	69.20	Tax consultancy			
 70	M	Activities of head offices; management consultancy activities			
 70.1	70	Activities of head offices			
-70.10	70.1	Activities of head offices	Gweithgareddau pencadlysoedd		
+70.10	70.1	Activities of head offices			
 70.2	70	Management consultancy activities			
-70.21	70.2	Public relations and communications activities	Gweithgareddau cysylltiadau cyhoeddus a chyfathrebu		
+70.21	70.2	Public relations and communication activities			
 70.22	70.2	Business and other management consultancy activities			
-70.22/1	70.22	Financial management	Rheolaeth ariannol		
-70.22/9	70.22	Management consultancy activities other than financial management	Gweithgareddau ymgynghoriaeth ar faterion rheoli ac eithrio rheolaeth ariannol		
+70.22/1	70.22	Financial management			
+70.22/9	70.22	Management consultancy activities (other than financial management)			
 71	M	Architectural and engineering activities; technical testing and analysis			
 71.1	71	Architectural and engineering activities and related technical consultancy			
 71.11	71.1	Architectural activities			
-71.11/1	71.11	Architectural activities	Gweithgareddau pensaernïol		
-71.11/2	71.11	Urban planning and landscape architectural activities	Gweithgareddau cynllunio trefol a phensaernïaeth y dirwedd		
+71.11/1	71.11	Architectural activities			
+71.11/2	71.11	Urban planning and landscape architectural activities			
 71.12	71.1	Engineering activities and related technical consultancy			
-71.12/1	71.12	Engineering design activities for industrial process and production	Gweithgareddau dylunio peirianneg ar gyfer prosesau a chynhyrchu diwydiannol		
-71.12/2	71.12	Engineering related scientific and technical consulting activities	Gweithgareddau ymgynghori gwyddonol a thechnegol ym maes peirianneg		
-71.12/9	71.12	Other engineering activities	Gweithgareddau peirianneg eraill		
+71.12/1	71.12	Engineering design activities for industrial process and production			
+71.12/2	71.12	Engineering related scientific and technical consulting activities			
+71.12/9	71.12	Other engineering activities (not including engineering design for industrial process and production or engineering related scientific and technical consulting activities)			
 71.2	71	Technical testing and analysis			
-71.20	71.2	Technical testing and analysis	Profi a dadansoddi technegol		
+71.20	71.2	Technical testing and analysis			
 72	M	Scientific research and development			
 72.1	72	Research and experimental development on natural sciences and engineering			
-72.11	72.1	Research and experimental development on biotechnology	Gwaith ymchwil a datblygu arbrofol ym maes biodechnoleg		
-72.19	72.1	Other research and experimental development on natural sciences and engineering	Gwaith ymchwil a datblygu arbrofol arall ym maes peirianneg a'r gwyddorau natur		
+72.11	72.1	Research and experimental development on biotechnology			
+72.19	72.1	Other research and experimental development on natural sciences and engineering			
 72.2	72	Research and experimental development on social sciences and humanities			
-72.20	72.2	Research and experimental development on social sciences and humanities	Gwaith ymchwil a datblygu arbrofol ym maes y gwyddorau cymdeithasol a'r dyniaethau		
+72.20	72.2	Research and experimental development on social sciences and humanities			
 73	M	Advertising and market research			
 73.1	73	Advertising			
-73.11	73.1	Advertising agencies	Asiantaethau hysbysebu		
-73.12	73.1	Media representation services	Gwasanaethau cynrychiolaeth ym maes y cyfryngau		
+73.11	73.1	Advertising agencies			
+73.12	73.1	Media representation			
 73.2	73	Market research and public opinion polling			
-73.20	73.2	Market research and public opinion polling	Ymchwil i'r farchnad ac arolygon barn		
+73.20	73.2	Market research and public opinion polling			
 74	M	Other professional, scientific and technical activities			
 74.1	74	Specialised design activities			
-74.10	74.1	specialised design activities	Gweithgareddau dylunio arbenigol		
+74.10	74.1	Specialised design activities			
 74.2	74	Photographic activities			
 74.20	74.2	Photographic activities			
-74.20/1	74.20	Portrait photographic activities	Gweithgareddau portreadu ffotograffig		
-74.20/2	74.20	Other specialist photography	Mathau eraill o ffotograffiaeth arbenigol		
-74.20/3	74.20	Film processing	Prosesu ffilmiau		
-74.20/9	74.20	Photographic activities not elsewhere classified	Gweithgareddau ffotograffig na ddosbarthwyd yn benodol		
+74.20/1	74.20	Portrait photographic activities			
+74.20/2	74.20	Other specialist photography (not including portrait photography)			
+74.20/3	74.20	Film processing			
+74.20/9	74.20	Other photographic activities (not including portrait and other specialist photography and film processing) not elsewhere classified			
 74.3	74	Translation and interpretation activities			
-74.30	74.3	Translation and interpretation activities	Gweithgareddau cyfieithu a chyfieithu ar y pryd		
+74.30	74.3	Translation and interpretation activities			
 74.9	74	Other professional, scientific and technical activities not elsewhere classified			
 74.90	74.9	Other professional, scientific and technical activities not elsewhere classified			
-74.90/1	74.90	Environmental consulting activities	Gweithgareddau ymgynghori amgylcheddol		
-74.90/2	74.90	Quantity surveying activities	Gweithgareddau mesur meintiau		
-74.90/9	74.90	Other professional, scientific and technical activities not elsewhere classified	Gweithgareddau proffesiynol, gwyddonol a thechnegol n.dd.b.		
+74.90/1	74.90	Environmental consulting activities			
+74.90/2	74.90	Quantity surveying activities			
+74.90/9	74.90	Other professional, scientific and technical activities (not including environmental consultancy or quantity surveying) not elsewhere classified			
 75	M	Veterinary activities			
 75.0	75	Veterinary activities			
-75.00	75.0	Veterinary activities	Gweithgareddau milfeddygol		
+75.00	75.0	Veterinary activities			
 77	N	Rental and leasing activities			
 77.1	77	Renting and leasing of motor vehicles			
-77.11	77.1	Renting and leasing of cars and light motor vehicles	Rhentu a phrydlesu ceir a cherbydau modur ysgafn		
-77.12	77.1	Renting and leasing of trucks and other heavy vehicles	Rhentu a phrydlesu tryciau a cherbydau trwm eraill		
+77.11	77.1	Renting and leasing of cars and light motor vehicles			
+77.12	77.1	Renting and leasing of trucks			
 77.2	77	Renting and leasing of personal and household goods			
-77.21	77.2	Renting and leasing of recreational and sports goods	Rhentu a phrydlesu nwyddau hamdden a chwaraeon		
-77.22	77.2	Renting of video tapes and disks	Rhentu tapiau a disgiau fideo		
+77.21	77.2	Renting and leasing of recreational and sports goods			
+77.22	77.2	Renting of video tapes and disks			
 77.29	77.2	Renting and leasing of other personal and household goods			
-77.29/1	77.29	Renting and leasing of media entertainment equipment	Rhentu a phrydlesu cyfarpar y cyfryngau adloniant		
-77.29/9	77.29	Renting and leasing of other personal and household goods	Rhentu a phrydlesu nwyddau personol a chartref eraill		
+77.29/1	77.29	Renting and leasing of media entertainment equipment			
+77.29/9	77.29	Renting and leasing of other personal and household goods (other than media entertainment equipment)			
 77.3	77	Renting and leasing of other machinery, equipment and tangible goods			
-77.31	77.3	Renting and leasing of agricultural machinery and equipment	Rhentu a phrydlesu peiriannau a chyfarpar amaethyddol		
-77.32	77.3	Renting and leasing of construction and civil engineering machinery and equipment	Rhentu a phrydlesu peiriannau a chyfarpar adeiladu a pheirianneg sifil		
-77.33	77.3	Renting and leasing of office machinery and equipment (including computers)	Rhentu a phrydlesu peiriannau a chyfarpar swyddfa (gan gynnwys cyfrifiaduron)		
+77.31	77.3	Renting and leasing of agricultural machinery and equipment			
+77.32	77.3	Renting and leasing of construction and civil engineering machinery and equipment			
+77.33	77.3	Renting and leasing of office machinery and equipment (including computers)			
 77.34	77.3	Renting and leasing of water transport equipment			
-77.34/1	77.34	Renting and leasing of passenger water transport equipment	Rhentu a phrydlesu cyfarpar i gludo teithwyr ar y dŵr		
-77.34/2	77.34	Renting and leasing of freight water transport equipment	Rhentu a phrydlesu cyfarpar i gludo nwyddau ar y dŵr		
+77.34/1	77.34	Renting and leasing of passenger water transport equipment			
+77.34/2	77.34	Renting and leasing of freight water transport equipment			
 77.35	77.3	Renting and leasing of air transport equipment			
-77.35/1	77.35	Renting and leasing of air passenger transport equipment	Rhentu a phrydlesu cyfarpar i gludo teithwyr yn yr awyr		
-77.35/2	77.35	Renting and leasing of freight air transport equipment	Rhentu a phrydlesu cyfarpar i gludo nwyddau yn yr awyr		
-77.39	77.3	Renting and leasing of other machinery, equipment and tangible goods not elsewhere classified	Rhentu a phrydlesu peiriannau, cyfarpar a nwyddau diriaethol eraill n.dd.b.		
+77.35/1	77.35	Renting and leasing of passenger air transport equipment			
+77.35/2	77.35	Renting and leasing of freight air transport equipment			
+77.39	77.3	Renting and leasing of other machinery, equipment and tangible goods not elsewhere classified			
 77.4	77	Leasing of intellectual property and similar products, except copyrighted works			
-77.40	77.4	Leasing of intellectual property and similar products, except copyright works	Prydlesu eiddo deallusol a chynnyrch tebyg, ac eithrio gwaith hawlfraint		
+77.40	77.4	Leasing of intellectual property and similar products, except copyrighted works			
 78	N	Employment activities			
 78.1	78	Activities of employment placement agencies			
 78.10	78.1	Activities of employment placement agencies			
-78.10/1	78.10	Motion picture, television and other theatrical casting activities	Gweithgareddau castio ar gyfer ffilmiau, y teledu a gweithgareddau theatraidd eraill		
-78.10/9	78.10	Other activities of employment placement agencies	Gweithgareddau eraill asiantaethau canfod cyflogaeth		
+78.10/1	78.10	Motion picture, television and other theatrical casting			
+78.10/9	78.10	Activities of employment placement agencies (other than motion picture, television and other theatrical casting) not elsewhere classified			
 78.2	78	Temporary employment agency activities			
-78.20	78.2	Temporary employment agency activities	Gweithgareddau asiantaethau canfod cyflogaeth dros dro		
+78.20	78.2	Temporary employment agency activities			
 78.3	78	Other human resources provision			
-78.30	78.3	Human resources provision and management of human resources functions	Darparu gwasanaethau adnoddau dynol a rheoli swyddogaethau adnoddau dynol		
+78.30	78.3	Other human resources provision			
 79	N	Travel agency, tour operator and other reservation service and related activities			
 79.1	79	Travel agency and tour operator activities			
-79.11	79.1	Travel agency activities	Gweithgareddau asiantaethau teithio		
-79.12	79.1	Tour operator activities	Gweithgareddau trefnwyr teithiau		
+79.11	79.1	Travel agency activities			
+79.12	79.1	Tour operator activities			
 79.9	79	Other reservation service and related activities			
 79.90	79.9	Other reservation service and related activities			
-79.90/1	79.90	Activities of tourist guides	Gweithgareddau tywyswyr twristiaid		
-79.90/9	79.90	Other reservation service activities not elsewhere classified	Gweithgareddau gwasanaethau bwcio a chadw eraill n.dd.b.		
+79.90/1	79.90	Activities of tourist guides			
+79.90/9	79.90	Other reservation service activities (not including activities of tourist guides)			
 80	N	Security and investigation activities			
 80.1	80	Private security activities			
-80.10	80.1	Private security activities	Gweithgareddau diogelwch preifat		
+80.10	80.1	Private security activities			
 80.2	80	Security systems service activities			
-80.20	80.2	Security systems service activities	Gweithgareddau gwasanaethau systemau diogelwch		
+80.20	80.2	Security systems service activities			
 80.3	80	Investigation activities			
-80.30	80.3	Investigation activities	Gwasanaethau ymholi		
+80.30	80.3	Investigation activities			
 81	N	Services to buildings and landscape activities			
 81.1	81	Combined facilities support activities			
-81.10	81.1	Combined facilities support activities	Gweithgareddau cynnal cyfleusterau cyfunol		
+81.10	81.1	Combined facilities support activities			
 81.2	81	Cleaning activities			
-81.21	81.2	General cleaning of buildings	Glanhau cyffredinol mewn adeiladau		
+81.21	81.2	General cleaning of buildings			
 81.22	81.2	Other building and industrial cleaning activities			
-81.22/1	81.22	Window cleaning services	Gwasanaethau glanhau ffenestri		
-81.22/2	81.22	Specialised cleaning services	Gwasanaethau glanhau arbenigol		
-81.22/3	81.22	Furnace and chimney cleaning services	Gwasanaethau glanhau ffwrneisi a simneiau		
-81.22/9	81.22	Other building and industrial cleaning activities	Gweithgareddau eraill ym maes glanhau adeiladau a glanhau diwydiannol		
+81.22/1	81.22	Window cleaning services			
+81.22/2	81.22	Specialised cleaning services			
+81.22/3	81.22	Furnace and chimney cleaning services			
+81.22/9	81.22	Building and industrial cleaning activities (other than window cleaning, specialised cleaning and furnace and chimney cleaning services) not elsewhere classified			
 81.29	81.2	Other cleaning activities			
-81.29/1	81.29	Disinfecting and exterminating services	Gweithgareddau diheintio a difodi		
-81.29/9	81.29	Other cleaning services	Gwasanaethau glanhau eraill		
+81.29/1	81.29	Disinfecting and extermination services			
+81.29/9	81.29	Cleaning services (other than disinfecting and extermination services) not elsewhere classified			
 81.3	81	Landscape service activities			
-81.30	81.3	Landscape service activities	Gweithgareddau gwasanaethau'r dirwedd		
+81.30	81.3	Landscape service activities			
 82	N	Office administrative, office support and other business support activities			
 82.1	82	Office administrative and support activities			
-82.11	82.1	Combined office administrative service activities	Gweithgareddau gwasanaethau gweinyddol cyfunol mewn swyddfeydd		
-82.19	82.1	Photocopying, document preparation and other specialised office support activities	Llungopïo, paratoi dogfennau a gweithgareddau cymorth arbenigol eraill ar gyfer swyddfeydd		
+82.11	82.1	Combined office administrative service activities			
+82.19	82.1	Photocopying, document preparation and other specialised office support activities			
 82.2	82	Activities of call centres			
-82.20	82.2	Activities of call centres	Gweithgareddau canolfannau galwadau		
+82.20	82.2	Activities of call centres			
 82.3	82	Organisation of conventions and trade shows			
 82.30	82.3	Organisation of conventions and trade shows			
-82.30/1	82.30	Activities of exhibition and fair organisers	Gweithgareddau trefnu arddangosfeydd a ffeiriau		
-82.30/2	82.30	Activities of conference organisers	Gweithgareddau trefnu cynadleddau		
+82.30/1	82.30	Activities of exhibition and fair organizers			
+82.30/2	82.30	Activities of conference organizers			
 82.9	82	Business support service activities not elsewhere classified			
 82.91	82.9	Activities of collection agencies and credit bureaus			
-82.91/1	82.91	Activities of collection agencies	Gweithgareddau asiantaethau casglu		
-82.91/2	82.91	Activities of credit bureaus	Gweithgareddau canolfannau credyd		
-82.92	82.9	Packaging activities	Gweithgareddau pecynnu		
-82.99	82.9	Other business support service activities not elsewhere classified	Gweithgareddau gwasanaethau cymorth busnes eraill n.dd.b.		
+82.91/1	82.91	Activities of collection agencies			
+82.91/2	82.91	Activities of credit bureaus			
+82.92	82.9	Packaging activities			
+82.99	82.9	Other business support service activities not elsewhere classified			
 84	O	Public administration and defence; compulsory social security			
 84.1	84	Administration of the State and the economic and social policy of the community			
-84.11	84.1	General public administration activities	Gweithgareddau cyffredinol ym maes gweinyddiaeth gyhoeddus		
-84.12	84.1	Regulation of health care, education, cultural and other social services, not incl. social security	Rheoleiddio gofal iechyd, addysg, diwylliant a gwasanaethau cymdeithasol eraill, heblaw nawdd cymdeithasol		
-84.13	84.1	Regulation of and contribution to more efficient operation of businesses	Rheoleiddio busnesau a'u helpu i weithredu'n fwy effeithlon		
+84.11	84.1	General public administration activities			
+84.12	84.1	Regulation of the activities of providing health care, education, cultural services and other social services, excluding social security			
+84.13	84.1	Regulation of and contribution to more efficient operation of businesses			
 84.2	84	Provision of services to the community as a whole			
-84.21	84.2	Foreign affairs	Materion tramor		
-84.22	84.2	Defence activities	Gweithgareddau amddiffyn		
-84.23	84.2	Justice and judicial activities	Gweithgareddau cyfiawnder a barnwrol		
-84.24	84.2	Public order and safety activities	Gweithgareddau'r drefn gyhoeddus a diogelwch		
-84.25	84.2	Fire service activities	Gweithgareddau gwasanaethau tân		
+84.21	84.2	Foreign affairs			
+84.22	84.2	Defence activities			
+84.23	84.2	Justice and judicial activities			
+84.24	84.2	Public order and safety activities			
+84.25	84.2	Fire service activities			
 84.3	84	Compulsory social security activities			
-84.30	84.3	Compulsory social security activities	Gweithgareddau gorfodol nawdd cymdeithasol		
+84.30	84.3	Compulsory social security activities			
 85	P	Education			
 85.1	85	Pre-primary education			
-85.10	85.1	Pre-primary education	Addysg cyn oedran cynradd		
+85.10	85.1	Pre-primary education			
 85.2	85	Primary education			
-85.20	85.2	Primary education	Addysg gynradd		
+85.20	85.2	Primary education			
 85.3	85	Secondary education			
-85.31	85.3	General secondary education	Addysg uwchradd gyffredinol		
-85.32	85.3	Technical and vocational secondary education	Addysg uwchradd dechnegol a galwedigaethol		
+85.31	85.3	General secondary education			
+85.32	85.3	Technical and vocational secondary education			
 85.4	85	Higher education			
-85.41	85.4	Post-secondary non-tertiary education	Addysg ôl-uwchradd nad yw'n drydyddol		
+85.41	85.4	Post-secondary non-tertiary education			
 85.42	85.4	Tertiary education			
-85.42/1	85.42	First-degree level higher education	Addysg uwch lefel gradd gyntaf		
-85.42/2	85.42	Post-graduate level higher education	Addysg uwch lefel olraddedig		
+85.42/1	85.42	First-degree level higher education			
+85.42/2	85.42	Post-graduate level higher education			
 85.5	85	Other education			
-85.51	85.5	Sports and recreation education	Addysg chwaraeon a hamdden		
-85.52	85.5	Cultural education	Addysg ddiwylliannol		
-85.53	85.5	Driving school activities	Gweithgareddau ysgolion gyrru		
-85.59	85.5	Other education not elsewhere classified	Addysg arall n.dd.b.		
+85.51	85.5	Sports and recreation education			
+85.52	85.5	Cultural education			
+85.53	85.5	Driving school activities			
+85.59	85.5	Other education not elsewhere classified			
 85.6	85	Educational support activities			
-85.60	85.6	Educational support services	Gwasanaethau cymorth addysg		
+85.60	85.6	Educational support activities			
 86	Q	Human health activities			
 86.1	86	Hospital activities			
 86.10	86.1	Hospital activities			
-86.10/1	86.10	Hospital activities	Gweithgareddau ysbytai		
-86.10/2	86.10	Medical nursing home activities	Gweithgareddau cartrefi nyrsio meddygol		
+86.10/1	86.10	Hospital activities			
+86.10/2	86.10	Medical nursing home activities			
 86.2	86	Medical and dental practice activities			
-86.21	86.2	General medical practice activities	Gweithgareddau practisau meddygol cyffredinol		
-86.22	86.2	Specialists medical practice activities	Gweithgareddau practisau meddygol arbenigol		
-86.23	86.2	Dental practice activities	Gweithgareddau practisau deintyddol		
+86.21	86.2	General medical practice activities			
+86.22	86.2	Specialist medical practice activities			
+86.23	86.2	Dental practice activities			
 86.9	86	Other human health activities			
-86.90	86.9	Other human health activities	Gweithgareddau eraill ym maes iechyd y cyhoedd		
+86.90	86.9	Other human health activities			
 87	Q	Residential care activities			
 87.1	87	Residential nursing care activities			
-87.10	87.1	Residential nursing care facilities	Cyfleusterau gofal nyrsio preswyl		
+87.10	87.1	Residential nursing care activities			
 87.2	87	Residential care activities for learning disabilities, mental health and substance abuse			
-87.20	87.2	Residential care activities for learning difficulties, mental health and substance abuse	Gweithgareddau gofal preswyl ar gyfer anawsterau dysgu, iechyd meddwl a cham-drin sylweddau		
+87.20	87.2	Residential care activities for learning disabilities, mental health and substance abuse			
 87.3	87	Residential care activities for the elderly and disabled			
-87.30	87.3	Residential care activities for the elderly and disabled	Gweithgareddau gofal preswyl ar gyfer pobl oedrannus ac anabl		
+87.30	87.3	Residential care activities for the elderly and disabled			
 87.9	87	Other residential care activities			
-87.90	87.9	Other residential care activities not elsewhere classified	Gweithgareddau eraill ym maes gofal preswyl n.dd.b.		
+87.90	87.9	Other residential care activities			
 88	Q	Social work activities without accommodation			
 88.1	88	Social work activities without accommodation for the elderly and disabled			
-88.10	88.1	Social work activities without accommodation for the elderly and disabled	Gweithgareddau gwaith cymdeithasol heb lety ar gyfer pobl oedrannus ac anabl		
+88.10	88.1	Social work activities without accommodation for the elderly and disabled			
 88.9	88	Other social work activities without accommodation			
-88.91	88.9	Child day-care activities	Gweithgareddau gofal dydd i blant		
-88.99	88.9	Other social work activities without accommodation not elsewhere classified	Gweithgareddau gofal cymdeithasol eraill heb lety n.dd.b.		
+88.91	88.9	Child day-care activities			
+88.99	88.9	Other social work activities without accommodation not elsewhere classified			
 90	R	Creative, arts and entertainment activities			
 90.0	90	Creative, arts and entertainment activities			
-90.01	90.0	Performing arts	Y celfyddydau perfformio		
-90.02	90.0	Support activities to performing arts	Gweithgareddau cymorth ym maes y celfyddydau perfformio		
-90.03	90.0	Artistic creation	Creu artistig		
-90.04	90.0	Operation of arts facilities	Rheoli cyfleusterau ar gyfer y celfyddydau		
+90.01	90.0	Performing arts			
+90.02	90.0	Support activities to performing arts			
+90.03	90.0	Artistic creation			
+90.04	90.0	Operation of arts facilities			
 91	R	Libraries, archives, museums and other cultural activities			
 91.0	91	Libraries, archives, museums and other cultural activities			
 91.01	91.0	Library and archive activities			
-91.01/1	91.01	Library activities	Gweithgareddau llyfrgelloedd		
-91.01/2	91.01	Archives activities	Gweithgareddau archifau		
-91.02	91.0	Museums activities	Gweithgareddau amgueddfeydd		
-91.03	91.0	Operation of historical sites and buildings and similar visitor attractions	Gweithredu safleoedd ac adeiladau hanesyddol ac atyniadau tebyg i ymwelwyr		
-91.04	91.0	Botanical and zoological gardens and nature reserves activities	Gweithgareddau gerddi botanegol a sŵolegol a gwarchodfeydd natur		
+91.01/1	91.01	Library activities			
+91.01/2	91.01	Archive activities			
+91.02	91.0	Museum activities			
+91.03	91.0	Operation of historical sites and buildings and similar visitor attractions			
+91.04	91.0	Botanical and zoological gardens and nature reserve activities			
 92	R	Gambling and betting activities			
 92.0	92	Gambling and betting activities			
-92.00	92.0	Gambling and betting activities	Gweithgareddau gamblo a betio		
+92.00	92.0	Gambling and betting activities			
 93	R	Sports activities and amusement and recreation activities			
 93.1	93	Sports activities			
-93.11	93.1	Operation of sports facilities	Gweithredu cyfleusterau chwaraeon		
-93.12	93.1	Activities of sport clubs	Gweithgareddau clybiau chwaraeon		
-93.13	93.1	Fitness facilities	Cyfleusterau ffitrwydd		
+93.11	93.1	Operation of sports facilities			
+93.12	93.1	Activities of sport clubs			
+93.13	93.1	Fitness facilities			
 93.19	93.1	Other sports activities			
-93.19/1	93.19	Activities of racehorse owners	Gweithgareddau perchnogion ceffylau rasio		
-93.19/9	93.19	Other sports activities	Gweithgareddau chwaraeon eraill		
+93.19/1	93.19	Activities of racehorse owners			
+93.19/9	93.19	Other sports activities (not including activities of racehorse owners) not elsewhere classified			
 93.2	93	Amusement and recreation activities			
-93.21	93.2	Activities of amusement parks and theme parks	Gweithgareddau parciau diddanu a pharciau thema		
-93.29	93.2	Other amusement and recreation activities not elsewhere classified	Gweithgareddau diddanu a hamdden eraill n.dd.b.		
+93.21	93.2	Activities of amusement parks and theme parks			
+93.29	93.2	Other amusement and recreation activities			
 94	S	Activities of membership organisations			
 94.1	94	Activities of business, employers and professional membership organisations			
-94.11	94.1	Activities of business and employers membership organisations	Gweithgareddau sefydliadau i aelodau ym myd busnes a chyflogwyr		
-94.12	94.1	Activities of professional membership organisations	Gweithgareddau sefydliadau proffesiynol i aelodau		
+94.11	94.1	Activities of business and employers membership organisations			
+94.12	94.1	Activities of professional membership organisations			
 94.2	94	Activities of trade unions			
-94.20	94.2	Activities of trade unions	Gweithgareddau undebau llafur		
+94.20	94.2	Activities of trade unions			
 94.9	94	Activities of other membership organisations			
-94.91	94.9	Activities of religious organisations	Gweithgareddau sefydliadau crefyddol		
-94.92	94.9	Activities of political organisations	Gweithgareddau sefydliadau gwleidyddol		
-94.99	94.9	Activities of other membership organisations not elsewhere classified	Gweithgareddau sefydliadau aelodaeth eraill n.dd.b.		
+94.91	94.9	Activities of religious organisations			
+94.92	94.9	Activities of political organisations			
+94.99	94.9	Activities of other membership organisations not elsewhere classified			
 95	S	Repair of computers and personal and household goods			
 95.1	95	Repair of computers and communication equipment			
-95.11	95.1	Repair of computers and peripheral equipment	Atgyweirio cyfrifiaduron a'u perifferolion		
-95.12	95.1	Repair of communication equipment	Atgyweirio cyfarpar cyfathrebu		
+95.11	95.1	Repair of computers and peripheral equipment			
+95.12	95.1	Repair of communication equipment			
 95.2	95	Repair of personal and household goods			
-95.21	95.2	Repair of consumer electronics	Atgyweirio cyfarpar electronig i ddefnyddwyr		
-95.22	95.2	Repair of household appliances and home and garden equipment	Atgyweirio dyfeisiau cartref a chyfarpar y cartref a'r ardd		
-95.23	95.2	Repair of footwear and leather goods	Atgyweirio esgidiau a nwyddau lledr		
-95.24	95.2	Repair of furniture and home furnishings	Atgyweirio celfi ac eitemau dodrefnu'r cartref		
-95.25	95.2	Repair of watches, clocks and jewellery	Atgyweirio watsys, clociau a gemwaith		
-95.29	95.2	Repair of personal and household goods not elsewhere classified	Atgyweirio nwyddau personol a chartref eraill n.dd.b.		
+95.21	95.2	Repair of consumer electronics			
+95.22	95.2	Repair of household appliances and home and garden equipment			
+95.23	95.2	Repair of footwear and leather goods			
+95.24	95.2	Repair of furniture and home furnishings			
+95.25	95.2	Repair of watches, clocks and jewellery			
+95.29	95.2	Repair of other personal and household goods			
 96	S	Other personal service activities			
 96.0	96	Other personal service activities			
-96.01	96.0	Washing and (dry-)cleaning of textile and fur products	Golchi a glanhau (sychlanhau) cynhyrchion tecstilau a ffwr		
-96.02	96.0	Hairdressing and other beauty treatment	Trin gwallt a thriniaethau harddwch eraill		
-96.03	96.0	Funeral and related activities	Angladdau a gweithgareddau cysylltiedig		
-96.04	96.0	Physical well-being activities	Gweithgareddau lles corfforol		
-96.09	96.0	Other service activities not elsewhere classified	Gweithgareddau gwasanaethau eraill n.dd.b.		
+96.01	96.0	Washing and (dry-)cleaning of textile and fur products			
+96.02	96.0	Hairdressing and other beauty treatment			
+96.03	96.0	Funeral and related activities			
+96.04	96.0	Physical well-being activities			
+96.09	96.0	Other personal service activities not elsewhere classified			
 97	T	Activities of households as employers of domestic personnel			
 97.0	97	Activities of households as employers of domestic personnel			
-97.00	97.0	Activities of households as employers of domestic personnel	Gweithgareddau aelwydydd fel cyflogwyr gweithwyr domestig		
+97.00	97.0	Activities of households as employers of domestic personnel			
 98	T	Undifferentiated goods- and services-producing activities of private households for own use			
 98.1	98	Undifferentiated goods-producing activities of private households for own use			
-98.10	98.1	Undifferentiated goods-producing activities of private households for own use	Gweithgareddau diwahaniaeth aelwydydd preifat i gynhyrchu nwyddau at eu defnydd eu hunain		
+98.10	98.1	Undifferentiated goods-producing activities of private households for own use			
 98.2	98	Undifferentiated service-producing activities of private households for own use			
-98.20	98.2	Undifferentiated service-producing activities of private households for own use	Gweithgareddau diwahaniaeth aelwydydd preifat i gynhyrchu gwasanaethau at eu defnydd eu hunain		
+98.20	98.2	Undifferentiated service-producing activities of private households for own use			
 99	U	Activities of extraterritorial organisations and bodies			
 99.0	99	Activities of extraterritorial organisations and bodies			
-99.00	99.0	Activities of extraterritorial organisations and bodies	Gweithgareddau sefydliadau a chyrff alldiriogaethol		
-A		Agriculture, Forestry and Fishing	Amaethyddiaeth, Coedwigaeth a Physgota		
-B		Mining and Quarrying	Mwyngloddio a Chwarela		
-C		Manufacturing	Gweithgynhyrchu		
-D		Electricity, gas, steam and air conditioning supply	Cyflenwi trydan, nwy, stêm a thymherwyr awyr		
-E		Water supply, sewerage, waste management and remediation activities	Gweithgareddau cyflenwi dŵr, carthffosiaeth, rheoli ac adfer gwastraff		
-F		Construction	Adeiladu		
-G		Wholesale and retail trade; repair of motor vehicles and motorcycles	Masnachu trwy gyfanwerthu ac adwerthu; atgyweirio cerbydau modur a beiciau modur		
-H		Transportation and storage	Cludio a storio		
-I		Accommodation and food service activities	Gweithgareddau llety a gwasanaethau bwyd eraill		
-J		Information and communication	Gwybodaeth a chyfathrebu		
-K		Financial and insurance activities	Gweithgareddau ariannol ac yswiriant		
-L		Real estate activities	Gweithgareddau eiddo diriaethol		
-M		Professional, scientific and technical activities	Gweithgareddau proffesiynol, gwyddonol a thechnegol		
-N		Administrative and support service activities	Gweithgareddau gweinyddol a gwasanethau cynorthwyol		
-O		Public administration and defence; compulsory social security	Gweinyddiaeth gyhoeddus ac amddiffyn; nawdd cymdeithasol gorfodol		
-P		Education	Addysg		
-Q		Human health and social work activities	Gweithgareddau iechyd y cyhoedd a gwaith cymdeithasol		
-R		Arts, entertainment and recreation	Y celfyddydau, adloniant a hamdden		
-S		Other service activities	Gwithgareddau gwasanaethu eraill		
-T		Activities of households as employers; undifferentiated goods- and services-producing activities of households for own use	Gwithgareddau aelwydydd fel cyflogwyr; gweithgareddau diwahaniaeth sy’n cynhyrchu nwydday – a gwasanethau – ar gyfer aelwydydd at eu defnydd eu hunain		
-U		Activities of extraterritorial organisations and bodies	Gweithgareddau sefydliadau a chyrff alldiriogaethol		
+99.00	99.0	Activities of extraterritorial organisations and bodies			
+A		AGRICULTURE, FORESTRY AND FISHING			
+B		MINING AND QUARRYING			
+C		MANUFACTURING			
+D		ELECTRICITY, GAS, STEAM AND AIR CONDITIONING SUPPLY			
+E		WATER SUPPLY; SEWERAGE, WASTE MANAGEMENT AND REMEDIATION ACTIVITIES			
+F		CONSTRUCTION			
+G		WHOLESALE AND RETAIL TRADE; REPAIR OF MOTOR VEHICLES AND MOTORCYCLES			
+H		TRANSPORTATION AND STORAGE			
+I		ACCOMMODATION AND FOOD SERVICE ACTIVITIES			
+J		INFORMATION AND COMMUNICATION			
+K		FINANCIAL AND INSURANCE ACTIVITIES			
+L		REAL ESTATE ACTIVITIES			
+M		PROFESSIONAL, SCIENTIFIC AND TECHNICAL ACTIVITIES			
+N		ADMINISTRATIVE AND SUPPORT SERVICE ACTIVITIES			
+O		PUBLIC ADMINISTRATION AND DEFENCE; COMPULSORY SOCIAL SECURITY			
+P		EDUCATION			
+Q		HUMAN HEALTH AND SOCIAL WORK ACTIVITIES			
+R		ARTS, ENTERTAINMENT AND RECREATION			
+S		OTHER SERVICE ACTIVITIES			
+T		ACTIVITIES OF HOUSEHOLDS AS EMPLOYERS; UNDIFFERENTIATED GOODS-AND SERVICES-PRODUCING ACTIVITIES OF HOUSEHOLDS FOR OWN USE			
+U		ACTIVITIES OF EXTRATERRITORIAL ORGANISATIONS AND BODIES			

--- a/data/industrial-classification/industrial-classification.tsv
+++ b/data/industrial-classification/industrial-classification.tsv
@@ -1,1170 +1,1170 @@
 industrial-classification	parent-industrial-classification	name	name-cy	start-date	end-date
 01	A	Crop and animal production, hunting and related service activities			
-011	01	Growing of non-perennial crops			
-01110	011	Growing of cereals (except rice), leguminous crops and oil seeds	Tyfu grawn (ac eithrio reis), cnydau o godlysiau ac olew had		
-01120	011	Growing of rice	Tyfu reis		
-01130	011	Growing of vegetables and melons, roots and tubers	Tyfu llysiau a melonau,gwreiddlysiau a chloron		
-01140	011	Growing of sugar cane	Tyfu câns siwgr		
-01150	011	Growing of tobacco	Tyfu tybaco		
-01160	011	Growing of fibre crops	Tyfu cnydau ffibrog		
-01190	011	Growing of other non-perennial crops	Tyfu cnydau eraill nad ydynt yn gnydau lluosflwydd		
-012	01	Growing of perennial crops			
-01210	012	Growing of grapes	Tyfu grawnwin		
-01220	012	Growing of tropical and subtropical fruits	Tyfu ffrwythau trofannol ac isdrofannol		
-01230	012	Growing of citrus fruits	Tyfu ffrwythau sitrws		
-01240	012	Growing of pome fruits and stone fruits	Tyfu ffrwythau o deulu'r afal a ffrwythau carreg		
-01250	012	Growing of other tree and bush fruits and nuts	Tyfu cnau a ffrwythau coed a pherth eraill		
-01260	012	Growing of oleaginous fruits	Tyfu ffrwythau olewaidd		
-01270	012	Growing of beverage crops	Tyfu cnydau gwneud diodydd		
-01280	012	Growing of spices, aromatic, drug and pharmaceutical crops	Tyfu cnydau sbeis, aromatig, cyffuriau a fferyllol		
-01290	012	Growing of other perennial crops	Tyfu cnydau lluosflwydd eraill		
-013	01	Plant propagation			
-01300	013	Plant propagation	Epilio planhigion		
-014	01	Animal production			
-01410	014	Raising of dairy cattle	Magu gwartheg godro		
-01420	014	Raising of other cattle and buffaloes	Magu gwartheg eraill a byfflos		
-01430	014	Raising of horses and other equines	Magu ceffylau ac anifeiliaid eraill o deulu'r ceffyl		
-01440	014	Raising of camels and camelids	Magu camelod a chamelidau		
-01450	014	Raising of sheep and  goats	Magu defaid a geifr		
-01460	014	Raising of swine/pigs	Magu moch/anifeiliaid o deulu'r mochyn		
-01470	014	Raising of poultry	Magu dofednod		
-01490	014	Raising of other animals	Magu anifeiliaid eraill		
-015	01	Mixed farming			
-01500	015	Mixed farming	Ffermio cymysg		
-016	01	Support activities to agriculture and post-harvest crop activities			
-01610	016	Support activities for crop production	Gweithgareddau cynorthwyol ym maes cynhyrchu cnydau		
-01620	016	Support activities for animal production			
-01621	01620	Farm animal boarding and care	Lletya a gofalu am anifeiliaid fferm		
-01629	01620	Support activities for animal production (other than farm animal boarding and care) not elsewhere classified	Gweithgareddau cynorthwyol ym maes magu anifeiliaid (ac eithrio lletya a gofalu am anifeiliaid fferm) n.dd.b.		
-01630	016	Post-harvest crop activities	Gweithgareddau yn sgil cynaeafu cnydau		
-01640	016	Seed processing for propagation	Prosesu hadau i'w hepilio		
-017	01	Hunting, trapping and related service activities			
-01700	017	Hunting, trapping and related service activities	Hela, maglu a gweithgareddau'r gwasanaethau cysylltiedig		
+01.1	01	Growing of non-perennial crops			
+01.11	01.1	Growing of cereals (except rice), leguminous crops and oil seeds	Tyfu grawn (ac eithrio reis), cnydau o godlysiau ac olew had		
+01.12	01.1	Growing of rice	Tyfu reis		
+01.13	01.1	Growing of vegetables and melons, roots and tubers	Tyfu llysiau a melonau,gwreiddlysiau a chloron		
+01.14	01.1	Growing of sugar cane	Tyfu câns siwgr		
+01.15	01.1	Growing of tobacco	Tyfu tybaco		
+01.16	01.1	Growing of fibre crops	Tyfu cnydau ffibrog		
+01.19	01.1	Growing of other non-perennial crops	Tyfu cnydau eraill nad ydynt yn gnydau lluosflwydd		
+01.2	01	Growing of perennial crops			
+01.21	01.2	Growing of grapes	Tyfu grawnwin		
+01.22	01.2	Growing of tropical and subtropical fruits	Tyfu ffrwythau trofannol ac isdrofannol		
+01.23	01.2	Growing of citrus fruits	Tyfu ffrwythau sitrws		
+01.24	01.2	Growing of pome fruits and stone fruits	Tyfu ffrwythau o deulu'r afal a ffrwythau carreg		
+01.25	01.2	Growing of other tree and bush fruits and nuts	Tyfu cnau a ffrwythau coed a pherth eraill		
+01.26	01.2	Growing of oleaginous fruits	Tyfu ffrwythau olewaidd		
+01.27	01.2	Growing of beverage crops	Tyfu cnydau gwneud diodydd		
+01.28	01.2	Growing of spices, aromatic, drug and pharmaceutical crops	Tyfu cnydau sbeis, aromatig, cyffuriau a fferyllol		
+01.29	01.2	Growing of other perennial crops	Tyfu cnydau lluosflwydd eraill		
+01.3	01	Plant propagation			
+01.30	01.3	Plant propagation	Epilio planhigion		
+01.4	01	Animal production			
+01.41	01.4	Raising of dairy cattle	Magu gwartheg godro		
+01.42	01.4	Raising of other cattle and buffaloes	Magu gwartheg eraill a byfflos		
+01.43	01.4	Raising of horses and other equines	Magu ceffylau ac anifeiliaid eraill o deulu'r ceffyl		
+01.44	01.4	Raising of camels and camelids	Magu camelod a chamelidau		
+01.45	01.4	Raising of sheep and  goats	Magu defaid a geifr		
+01.46	01.4	Raising of swine/pigs	Magu moch/anifeiliaid o deulu'r mochyn		
+01.47	01.4	Raising of poultry	Magu dofednod		
+01.49	01.4	Raising of other animals	Magu anifeiliaid eraill		
+01.5	01	Mixed farming			
+01.50	01.5	Mixed farming	Ffermio cymysg		
+01.6	01	Support activities to agriculture and post-harvest crop activities			
+01.61	01.6	Support activities for crop production	Gweithgareddau cynorthwyol ym maes cynhyrchu cnydau		
+01.62	01.6	Support activities for animal production			
+01.62/1	01.62	Farm animal boarding and care	Lletya a gofalu am anifeiliaid fferm		
+01.62/9	01.62	Support activities for animal production (other than farm animal boarding and care) not elsewhere classified	Gweithgareddau cynorthwyol ym maes magu anifeiliaid (ac eithrio lletya a gofalu am anifeiliaid fferm) n.dd.b.		
+01.63	01.6	Post-harvest crop activities	Gweithgareddau yn sgil cynaeafu cnydau		
+01.64	01.6	Seed processing for propagation	Prosesu hadau i'w hepilio		
+01.7	01	Hunting, trapping and related service activities			
+01.70	01.7	Hunting, trapping and related service activities	Hela, maglu a gweithgareddau'r gwasanaethau cysylltiedig		
 02	A	Forestry and logging			
-021	02	Silviculture and other forestry activities			
-02100	021	Silviculture and other forestry activities	Tyfu coed a gweithgareddau coedwigaeth eraill		
-022	02	Logging			
-02200	022	Logging	Torri coed yn foncyffion		
-023	02	Gathering of wild growing non-wood products			
-02300	023	Gathering of wild growing non-wood products	Casglu cynnyrch sy'n tyfu'n wyllt heblaw pren		
-024	02	Support services to forestry			
-02400	024	Support services to forestry	Gwasanaethau cynorthwyol ym maes coedwigaeth		
+02.1	02	Silviculture and other forestry activities			
+02.10	02.1	Silviculture and other forestry activities	Tyfu coed a gweithgareddau coedwigaeth eraill		
+02.2	02	Logging			
+02.20	02.2	Logging	Torri coed yn foncyffion		
+02.3	02	Gathering of wild growing non-wood products			
+02.30	02.3	Gathering of wild growing non-wood products	Casglu cynnyrch sy'n tyfu'n wyllt heblaw pren		
+02.4	02	Support services to forestry			
+02.40	02.4	Support services to forestry	Gwasanaethau cynorthwyol ym maes coedwigaeth		
 03	A	Fishing and aquaculture			
-031	03	Fishing			
-03110	031	Marine fishing	Pysgota morol		
-03120	031	Freshwater fishing	Pysgota dŵr croyw		
-032	03	Aquaculture			
-03210	032	Marine aquaculture	Acwafeithrin morol		
-03220	032	Freshwater aquaculture	Acwafeithrin mewn dŵr croyw		
+03.1	03	Fishing			
+03.11	03.1	Marine fishing	Pysgota morol		
+03.12	03.1	Freshwater fishing	Pysgota dŵr croyw		
+03.2	03	Aquaculture			
+03.21	03.2	Marine aquaculture	Acwafeithrin morol		
+03.22	03.2	Freshwater aquaculture	Acwafeithrin mewn dŵr croyw		
 05	B	Mining of coal and lignite			
-051	05	Mining of hard coal			
-05100	051	Mining of hard coal			
-05101	05100	Deep coal mines	Pyllau glo dwfn		
-05102	05100	Open cast coal working	Cloddfeydd glo brig		
-052	05	Mining of lignite			
-05200	052	Mining of lignite	Mwyngloddio coedlo (lignit)		
+05.1	05	Mining of hard coal			
+05.10	05.1	Mining of hard coal			
+05.10/1	05.10	Deep coal mines	Pyllau glo dwfn		
+05.10/2	05.10	Open cast coal working	Cloddfeydd glo brig		
+05.2	05	Mining of lignite			
+05.20	05.2	Mining of lignite	Mwyngloddio coedlo (lignit)		
 06	B	Extraction of crude petroleum and natural gas			
-061	06	Extraction of crude petroleum			
-06100	061	Extraction of crude petroleum	Echdynnu petrolewm crai		
-062	06	Extraction of natural gas			
-06200	062	Extraction of natural gas	Echdynnu nwyon naturiol		
+06.1	06	Extraction of crude petroleum			
+06.10	06.1	Extraction of crude petroleum	Echdynnu petrolewm crai		
+06.2	06	Extraction of natural gas			
+06.20	06.2	Extraction of natural gas	Echdynnu nwyon naturiol		
 07	B	Mining of metal ores			
-071	07	Mining of iron ores			
-07100	071	Mining of iron ores	Mwyngloddio mwynau haearn		
-072	07	Mining of non-ferrous metal ores			
-07210	072	Mining of uranium and thorium ores	Mwyngloddio mwynau wraniwm a thoriwm		
-07290	072	Mining of other non-ferrous metal ores	Mwyngloddio mwynau metel anfferrus eraill		
+07.1	07	Mining of iron ores			
+07.10	07.1	Mining of iron ores	Mwyngloddio mwynau haearn		
+07.2	07	Mining of non-ferrous metal ores			
+07.21	07.2	Mining of uranium and thorium ores	Mwyngloddio mwynau wraniwm a thoriwm		
+07.29	07.2	Mining of other non-ferrous metal ores	Mwyngloddio mwynau metel anfferrus eraill		
 08	B	Other mining and quarrying			
-081	08	Quarrying of stone, sand and clay			
-08110	081	Quarrying of ornamental and building stone, limestone, gypsum, chalk and slate	Chwarela cerrig addurnol a cherrig adeiladu, calchfaen, gypswm, sialc a llechi		
-08120	081	Operation of gravel and sand pits; mining of clays and kaolin	Gweithredu pyllau graean a thywod; mwyngloddio clai a chaolin		
-089	08	Mining and quarrying not elsewhere classified			
-08910	089	Mining of chemical and fertilizer minerals	Mwyngloddio mwynau cemegol a gwrteithio		
-08920	089	Extraction of peat	Echdynnu mawn		
-08930	089	Extraction of salt	Echdynnu halen		
-08990	089	Other mining and quarrying not elsewhere classified	Gweithgareddau mwyngloddio a chwarela eraill n.dd.b.		
+08.1	08	Quarrying of stone, sand and clay			
+08.11	08.1	Quarrying of ornamental and building stone, limestone, gypsum, chalk and slate	Chwarela cerrig addurnol a cherrig adeiladu, calchfaen, gypswm, sialc a llechi		
+08.12	08.1	Operation of gravel and sand pits; mining of clays and kaolin	Gweithredu pyllau graean a thywod; mwyngloddio clai a chaolin		
+08.9	08	Mining and quarrying not elsewhere classified			
+08.91	08.9	Mining of chemical and fertilizer minerals	Mwyngloddio mwynau cemegol a gwrteithio		
+08.92	08.9	Extraction of peat	Echdynnu mawn		
+08.93	08.9	Extraction of salt	Echdynnu halen		
+08.99	08.9	Other mining and quarrying not elsewhere classified	Gweithgareddau mwyngloddio a chwarela eraill n.dd.b.		
 09	B	Mining support service activities			
-091	09	Support activities for petroleum and natural gas extraction			
-09100	091	Support activities for petroleum and natural gas mining	Gweithgareddau cynorthwyol ym maes mwyngloddio petrolewm a nwy naturiol		
-099	09	Support activities for other mining and quarrying			
-09900	099	Support activities for other mining and quarrying	Gweithgareddau cynorthwyol mwyngloddio a chwarela arall		
+09.1	09	Support activities for petroleum and natural gas extraction			
+09.10	09.1	Support activities for petroleum and natural gas mining	Gweithgareddau cynorthwyol ym maes mwyngloddio petrolewm a nwy naturiol		
+09.9	09	Support activities for other mining and quarrying			
+09.90	09.9	Support activities for other mining and quarrying	Gweithgareddau cynorthwyol mwyngloddio a chwarela arall		
 10	C	Manufacture of food products			
-101	10	Processing and preserving of meat and production of meat products			
-10110	101	Processing and preserving of meat	Prosesu a chyffeithio cig		
-10120	101	Processing and preserving of poultry meat	Prosesu a chyffeithio cig dofednod		
-10130	101	Production of meat and poultry meat products	Cynhyrchu cynhyrchion cig a dofednod		
-102	10	Processing and preserving of fish, crustaceans and molluscs			
-10200	102	Processing and preserving of fish, crustaceans and molluscs	Prosesu a chyffeithio pysgod, cramenogion a molysgiaid		
-103	10	Processing and preserving of fruit and vegetables			
-10310	103	Processing and preserving of potatoes	Prosesu a chyffeithio tatws		
-10320	103	Manufacture of fruit and vegetable juice	Gweithgynhyrchu sudd ffrwythau a llysiau		
-10390	103	Other processing and preserving of fruit and vegetables	Prosesu a chyffeithio ffrwythau a llysiau at ddibenion eraill		
-104	10	Manufacture of vegetable and animal oils and fats			
-10410	104	Manufacture of oils and fats	Gweithgynhyrchu olewon a brasterau		
-10420	104	Manufacture of margarine and similar edible fats	Gweithgynhyrchu margarin a brasterau bwytadwy tebyg		
-105	10	Manufacture of dairy products			
-10510	105	Operation of dairies and cheese making			
-10511	10510	Liquid milk and cream production	Cynhyrchu llaeth a hufen hylifol		
-10512	10510	Butter and cheese production	Cynhyrchu menyn a chaws		
-10519	10510	Manufacture of other milk products	Gweithgynhyrchu cynnyrch llaeth arall		
-10520	105	Manufacture of ice cream	Gweithgynhyrchu hufen iâ		
-106	10	Manufacture of grain mill products, starches and starch products			
-10610	106	Manufacture of grain mill products			
-10611	10610	Grain milling	Melino grawn		
-10612	10610	Manufacture of breakfast cereals and cereals-based food	Gweithgynhyrchu grawnfwydydd brecwast a grawnfwydydd eraill		
-10620	106	Manufacture of starches and starch products	Gweithgynhyrchu startsh a chynnyrch startsh		
-107	10	Manufacture of bakery and farinaceous products			
-10710	107	Manufacture of bread; manufacture of fresh pastry goods and cakes	Gweithgynhyrchu bara; gweithgynhyrchu teisennau a chacennau ffres		
-10720	107	Manufacture of rusks and biscuits; manufacture of preserved pastry goods and cakes	Gweithgynhyrchu rhysgenni a bisgedi; gweithgynhyrchu teisennau a chacennau cadw		
-10730	107	Manufacture of macaroni, noodles, couscous and similar farinaceous products	Gweithgynhyrchu macaroni, nwdls, couscous a chynnyrch cannog tebyg		
-108	10	Manufacture of other food products			
-10810	108	Manufacture of sugar	Gweithgynhyrchu siwgr		
-10820	108	Manufacture of cocoa, chocolate and sugar confectionery			
-10821	10820	Manufacture of cocoa and chocolate confectionery	Gweithgynhyrchu melysion coco a siocled		
-10822	10820	Manufacture of sugar confectionery	Gweithgynhyrchu melysion siwgr		
-10830	108	Processing of tea and coffee			
-10831	10830	Tea processing	Prosesu te		
-10832	10830	Production of coffee and coffee substitutes	Cynhyrchu coffi ac amnewidion coffi		
-10840	108	Manufacture of condiments and seasonings	Gweithgynhyrchu confennau a sesnin		
-10850	108	Manufacture of prepared meals and dishes	Gweithgynhyrchu prydau a seigiau parod		
-10860	108	Manufacture of homogenized food preparations and dietetic food	Gweithgynhyrchu bwydydd homogenaidd a lluniaethol		
-10890	108	Manufacture of other food products not elsewhere classified	Gweithgynhyrchu cynnyrch bwyd arall n.dd.b.		
-109	10	Manufacture of prepared animal feeds			
-10910	109	Manufacture of prepared feeds for farm animals	Gweithgynhyrchu bwydydd parod ar gyfer anifeiliaid fferm		
-10920	109	Manufacture of prepared pet foods	Gweithgynhyrchu bwydydd parod ar gyfer anifeiliaid anwes		
+10.1	10	Processing and preserving of meat and production of meat products			
+10.11	10.1	Processing and preserving of meat	Prosesu a chyffeithio cig		
+10.12	10.1	Processing and preserving of poultry meat	Prosesu a chyffeithio cig dofednod		
+10.13	10.1	Production of meat and poultry meat products	Cynhyrchu cynhyrchion cig a dofednod		
+10.2	10	Processing and preserving of fish, crustaceans and molluscs			
+10.20	10.2	Processing and preserving of fish, crustaceans and molluscs	Prosesu a chyffeithio pysgod, cramenogion a molysgiaid		
+10.3	10	Processing and preserving of fruit and vegetables			
+10.31	10.3	Processing and preserving of potatoes	Prosesu a chyffeithio tatws		
+10.32	10.3	Manufacture of fruit and vegetable juice	Gweithgynhyrchu sudd ffrwythau a llysiau		
+10.39	10.3	Other processing and preserving of fruit and vegetables	Prosesu a chyffeithio ffrwythau a llysiau at ddibenion eraill		
+10.4	10	Manufacture of vegetable and animal oils and fats			
+10.41	10.4	Manufacture of oils and fats	Gweithgynhyrchu olewon a brasterau		
+10.42	10.4	Manufacture of margarine and similar edible fats	Gweithgynhyrchu margarin a brasterau bwytadwy tebyg		
+10.5	10	Manufacture of dairy products			
+10.51	10.5	Operation of dairies and cheese making			
+10.51/1	10.51	Liquid milk and cream production	Cynhyrchu llaeth a hufen hylifol		
+10.51/2	10.51	Butter and cheese production	Cynhyrchu menyn a chaws		
+10.51/9	10.51	Manufacture of other milk products	Gweithgynhyrchu cynnyrch llaeth arall		
+10.52	10.5	Manufacture of ice cream	Gweithgynhyrchu hufen iâ		
+10.6	10	Manufacture of grain mill products, starches and starch products			
+10.61	10.6	Manufacture of grain mill products			
+10.61/1	10.61	Grain milling	Melino grawn		
+10.61/2	10.61	Manufacture of breakfast cereals and cereals-based food	Gweithgynhyrchu grawnfwydydd brecwast a grawnfwydydd eraill		
+10.62	10.6	Manufacture of starches and starch products	Gweithgynhyrchu startsh a chynnyrch startsh		
+10.7	10	Manufacture of bakery and farinaceous products			
+10.71	10.7	Manufacture of bread; manufacture of fresh pastry goods and cakes	Gweithgynhyrchu bara; gweithgynhyrchu teisennau a chacennau ffres		
+10.72	10.7	Manufacture of rusks and biscuits; manufacture of preserved pastry goods and cakes	Gweithgynhyrchu rhysgenni a bisgedi; gweithgynhyrchu teisennau a chacennau cadw		
+10.73	10.7	Manufacture of macaroni, noodles, couscous and similar farinaceous products	Gweithgynhyrchu macaroni, nwdls, couscous a chynnyrch cannog tebyg		
+10.8	10	Manufacture of other food products			
+10.81	10.8	Manufacture of sugar	Gweithgynhyrchu siwgr		
+10.82	10.8	Manufacture of cocoa, chocolate and sugar confectionery			
+10.82/1	10.82	Manufacture of cocoa and chocolate confectionery	Gweithgynhyrchu melysion coco a siocled		
+10.82/2	10.82	Manufacture of sugar confectionery	Gweithgynhyrchu melysion siwgr		
+10.83	10.8	Processing of tea and coffee			
+10.83/1	10.83	Tea processing	Prosesu te		
+10.83/2	10.83	Production of coffee and coffee substitutes	Cynhyrchu coffi ac amnewidion coffi		
+10.84	10.8	Manufacture of condiments and seasonings	Gweithgynhyrchu confennau a sesnin		
+10.85	10.8	Manufacture of prepared meals and dishes	Gweithgynhyrchu prydau a seigiau parod		
+10.86	10.8	Manufacture of homogenized food preparations and dietetic food	Gweithgynhyrchu bwydydd homogenaidd a lluniaethol		
+10.89	10.8	Manufacture of other food products not elsewhere classified	Gweithgynhyrchu cynnyrch bwyd arall n.dd.b.		
+10.9	10	Manufacture of prepared animal feeds			
+10.91	10.9	Manufacture of prepared feeds for farm animals	Gweithgynhyrchu bwydydd parod ar gyfer anifeiliaid fferm		
+10.92	10.9	Manufacture of prepared pet foods	Gweithgynhyrchu bwydydd parod ar gyfer anifeiliaid anwes		
 11	C	Manufacture of beverages			
-110	11	Manufacture of beverages			
-11010	110	Distilling, rectifying and blending of spirits	Distyllu, puro a chymysgu gwirodydd		
-11020	110	Manufacture of wine from grape	Gweithgynhyrchu gwin o rawnwin		
-11030	110	Manufacture of cider and other fruit wines	Gweithgynhyrchu seidr a mathau eraill o winoedd ffrwyth		
-11040	110	Manufacture of other non-distilled fermented beverages	Gweithgynhyrchu diodydd brag eraill heb eu distyllu		
-11050	110	Manufacture of beer	Gweithgynhyrchu cwrw		
-11060	110	Manufacture of malt	Gweithgynhyrchu brag		
-11070	110	Manufacture of soft drinks; production of mineral waters and other bottled waters	Gweithgynhyrchu diodydd ysgafn; cynhyrchu dŵr mwynol a dŵr potel arall		
+11.0	11	Manufacture of beverages			
+11.01	11.0	Distilling, rectifying and blending of spirits	Distyllu, puro a chymysgu gwirodydd		
+11.02	11.0	Manufacture of wine from grape	Gweithgynhyrchu gwin o rawnwin		
+11.03	11.0	Manufacture of cider and other fruit wines	Gweithgynhyrchu seidr a mathau eraill o winoedd ffrwyth		
+11.04	11.0	Manufacture of other non-distilled fermented beverages	Gweithgynhyrchu diodydd brag eraill heb eu distyllu		
+11.05	11.0	Manufacture of beer	Gweithgynhyrchu cwrw		
+11.06	11.0	Manufacture of malt	Gweithgynhyrchu brag		
+11.07	11.0	Manufacture of soft drinks; production of mineral waters and other bottled waters	Gweithgynhyrchu diodydd ysgafn; cynhyrchu dŵr mwynol a dŵr potel arall		
 12	C	Manufacture of tobacco products			
-120	12	Manufacture of tobacco products			
-12000	120	Manufacture of tobacco products	Gweithgynhyrchu cynnyrch tybaco		
+12.0	12	Manufacture of tobacco products			
+12.00	12.0	Manufacture of tobacco products	Gweithgynhyrchu cynnyrch tybaco		
 13	C	Manufacture of textiles			
-131	13	Preparation and spinning of textile fibres			
-13100	131	Preparation and spinning of textile fibres	Paratoi a nyddu ffibrau gweol		
-132	13	Weaving of textiles			
-13200	132	Weaving of textiles	Gwehyddu tecstilau		
-133	13	Finishing of textiles			
-13300	133	Finishing of textiles	Gorffennu tecstilau		
-139	13	Manufacture of other textiles			
-13910	139	Manufacture of knitted and crocheted fabrics	Gweithgynhyrchu ffabrig wedi'i wau a'i grosio		
-13920	139	Manufacture of made-up textile articles, except apparel			
-13921	13920	Manufacture of soft furnishings	Gweithgynhyrchu dodrefn meddal		
-13922	13920	manufacture of canvas goods, sacks, etc.	Gweithgynhyrchu nwyddau cynfas, sachau ac ati		
-13923	13920	manufacture of household textiles	Gweithgynhyrchu tecstilau cartref		
-13930	139	Manufacture of carpets and rugs			
-13931	13930	Manufacture of woven or tufted carpets and rugs	Gweithgynhyrchu carpedi a rygiau codennog neu wedi'u gwehyddu		
-13939	13930	Manufacture of other carpets and rugs	Gweithgynhyrchu carpedi a rygiau eraill		
-13940	139	Manufacture of cordage, rope, twine and netting	Gweithgynhyrchu deunyddiau rhaffog, rhaffau, cortynnau a rhwydi		
-13950	139	Manufacture of non-wovens and articles made from non-wovens, except apparel	Gweithgynhyrchu nwyddau heb eu gwehyddu a nwyddau o ddeunyddiau heb eu gwehyddu, ac eithrio dillad		
-13960	139	Manufacture of other technical and industrial textiles	Gweithgynhyrchu tecstilau technegol a diwydiannol eraill		
-13990	139	Manufacture of other textiles not elsewhere classified	Gweithgynhyrchu tecstilau eraill n.dd.b.		
+13.1	13	Preparation and spinning of textile fibres			
+13.10	13.1	Preparation and spinning of textile fibres	Paratoi a nyddu ffibrau gweol		
+13.2	13	Weaving of textiles			
+13.20	13.2	Weaving of textiles	Gwehyddu tecstilau		
+13.3	13	Finishing of textiles			
+13.30	13.3	Finishing of textiles	Gorffennu tecstilau		
+13.9	13	Manufacture of other textiles			
+13.91	13.9	Manufacture of knitted and crocheted fabrics	Gweithgynhyrchu ffabrig wedi'i wau a'i grosio		
+13.92	13.9	Manufacture of made-up textile articles, except apparel			
+13.92/1	13.92	Manufacture of soft furnishings	Gweithgynhyrchu dodrefn meddal		
+13.92/2	13.92	manufacture of canvas goods, sacks, etc.	Gweithgynhyrchu nwyddau cynfas, sachau ac ati		
+13.92/3	13.92	manufacture of household textiles	Gweithgynhyrchu tecstilau cartref		
+13.93	13.9	Manufacture of carpets and rugs			
+13.93/1	13.93	Manufacture of woven or tufted carpets and rugs	Gweithgynhyrchu carpedi a rygiau codennog neu wedi'u gwehyddu		
+13.93/9	13.93	Manufacture of other carpets and rugs	Gweithgynhyrchu carpedi a rygiau eraill		
+13.94	13.9	Manufacture of cordage, rope, twine and netting	Gweithgynhyrchu deunyddiau rhaffog, rhaffau, cortynnau a rhwydi		
+13.95	13.9	Manufacture of non-wovens and articles made from non-wovens, except apparel	Gweithgynhyrchu nwyddau heb eu gwehyddu a nwyddau o ddeunyddiau heb eu gwehyddu, ac eithrio dillad		
+13.96	13.9	Manufacture of other technical and industrial textiles	Gweithgynhyrchu tecstilau technegol a diwydiannol eraill		
+13.99	13.9	Manufacture of other textiles not elsewhere classified	Gweithgynhyrchu tecstilau eraill n.dd.b.		
 14	C	Manufacture of wearing apparel			
-141	14	Manufacture of wearing apparel, except fur apparel			
-14110	141	Manufacture of leather clothes	Gweithgynhyrchu dillad lledr		
-14120	141	Manufacture of workwear	Gweithgynhyrchu dillad gwaith		
-14130	141	Manufacture of other outerwear			
-14131	14130	Manufacture of other men's outerwear	Gweithgynhyrchu dillad uchaf eraill i ddynion		
-14132	14130	Manufacture of other women's outerwear	Gweithgynhyrchu dillad uchaf eraill i fenywod		
-14140	141	Manufacture of underwear			
-14141	14140	Manufacture of men's underwear	Gweithgynhyrchu dillad isaf i ddynion		
-14142	14140	Manufacture of women's underwear	Gweithgynhyrchu dillad isaf i fenywod		
-14190	141	Manufacture of other wearing apparel and accessories not elsewhere classified	Gweithgynhyrchu dillad ac ategolion eraill n.dd.b.		
-142	14	Manufacture of articles of fur			
-14200	142	Manufacture of articles of fur	Gweithgynhyrchu eitemau ffwr		
-143	14	Manufacture of knitted and crocheted apparel			
-14310	143	Manufacture of knitted and crocheted hosiery	Gweithgynhyrchu hosanwaith wedi'i wau a'i grosio		
-14390	143	Manufacture of other knitted and crocheted apparel	Gweithgynhyrchu dillad eraill wedi'i gwau a’u crosio		
+14.1	14	Manufacture of wearing apparel, except fur apparel			
+14.11	14.1	Manufacture of leather clothes	Gweithgynhyrchu dillad lledr		
+14.12	14.1	Manufacture of workwear	Gweithgynhyrchu dillad gwaith		
+14.13	14.1	Manufacture of other outerwear			
+14.13/1	14.13	Manufacture of other men's outerwear	Gweithgynhyrchu dillad uchaf eraill i ddynion		
+14.13/2	14.13	Manufacture of other women's outerwear	Gweithgynhyrchu dillad uchaf eraill i fenywod		
+14.14	14.1	Manufacture of underwear			
+14.14/1	14.14	Manufacture of men's underwear	Gweithgynhyrchu dillad isaf i ddynion		
+14.14/2	14.14	Manufacture of women's underwear	Gweithgynhyrchu dillad isaf i fenywod		
+14.19	14.1	Manufacture of other wearing apparel and accessories not elsewhere classified	Gweithgynhyrchu dillad ac ategolion eraill n.dd.b.		
+14.2	14	Manufacture of articles of fur			
+14.20	14.2	Manufacture of articles of fur	Gweithgynhyrchu eitemau ffwr		
+14.3	14	Manufacture of knitted and crocheted apparel			
+14.31	14.3	Manufacture of knitted and crocheted hosiery	Gweithgynhyrchu hosanwaith wedi'i wau a'i grosio		
+14.39	14.3	Manufacture of other knitted and crocheted apparel	Gweithgynhyrchu dillad eraill wedi'i gwau a’u crosio		
 15	C	Manufacture of leather and related products			
-151	15	Tanning and dressing of leather; manufacture of luggage, handbags, saddlery and harness; dressing and dyeing of fur			
-15110	151	Tanning and dressing of leather; dressing and dyeing of fur	Barcio a thrin lledr; trin a lliwio ffwr		
-15120	151	Manufacture of luggage, handbags and the like, saddlery and harness	Gweithgynhyrchu bagiau, bagiau llaw ac ati, cyfrwyon a harneisi		
-152	15	Manufacture of footwear			
-15200	152	Manufacture of footwear	Gweithgynhyrchu esgidiau		
+15.1	15	Tanning and dressing of leather; manufacture of luggage, handbags, saddlery and harness; dressing and dyeing of fur			
+15.11	15.1	Tanning and dressing of leather; dressing and dyeing of fur	Barcio a thrin lledr; trin a lliwio ffwr		
+15.12	15.1	Manufacture of luggage, handbags and the like, saddlery and harness	Gweithgynhyrchu bagiau, bagiau llaw ac ati, cyfrwyon a harneisi		
+15.2	15	Manufacture of footwear			
+15.20	15.2	Manufacture of footwear	Gweithgynhyrchu esgidiau		
 16	C	Manufacture of wood and of products of wood and cork, except furniture; manufacture of articles of straw and plaiting materials			
-161	16	Sawmilling and planing of wood			
-16100	161	Sawmilling and planing of wood	Llifio a phlaenio pren		
-162	16	Manufacture of products of wood, cork, straw and plaiting materials			
-16210	162	Manufacture of veneer sheets and wood-based panels	Gweithgynhyrchu dalenni argaen a phaneli o bren		
-16220	162	Manufacture of assembled parquet floors	Gweithgynhyrchu lloriau parquet parod		
-16230	162	Manufacture of other builders' carpentry and joinery	Gweithgynhyrchu gwaith coed a gwaith saer arall ar gyfer adeiladwyr		
-16240	162	Manufacture of wooden containers	Gweithgynhyrchu cynwysyddion pren		
-16290	162	Manufacture of other products of wood; manufacture of articles of cork, straw and plaiting materials	Gweithgynhyrchu cynhyrchion pren eraill; gweithgynhyrchu deunyddiau corc, gwellt a phleth		
+16.1	16	Sawmilling and planing of wood			
+16.10	16.1	Sawmilling and planing of wood	Llifio a phlaenio pren		
+16.2	16	Manufacture of products of wood, cork, straw and plaiting materials			
+16.21	16.2	Manufacture of veneer sheets and wood-based panels	Gweithgynhyrchu dalenni argaen a phaneli o bren		
+16.22	16.2	Manufacture of assembled parquet floors	Gweithgynhyrchu lloriau parquet parod		
+16.23	16.2	Manufacture of other builders' carpentry and joinery	Gweithgynhyrchu gwaith coed a gwaith saer arall ar gyfer adeiladwyr		
+16.24	16.2	Manufacture of wooden containers	Gweithgynhyrchu cynwysyddion pren		
+16.29	16.2	Manufacture of other products of wood; manufacture of articles of cork, straw and plaiting materials	Gweithgynhyrchu cynhyrchion pren eraill; gweithgynhyrchu deunyddiau corc, gwellt a phleth		
 17	C	Manufacture of paper and paper products			
-171	17	Manufacture of pulp, paper and paperboard			
-17110	171	Manufacture of pulp	Gweithgynhyrchu mwydion pren		
-17120	171	Manufacture of paper and paperboard	Gweithgynhyrchu papur a bwrdd papur		
-172	17	Manufacture of articles of paper and paperboard			
-17210	172	Manufacture of corrugated paper and paperboard and of containers of paper and paperboard			
-17211	17210	Manufacture of corrugated paper and paperboard, sacks and bags	Gweithgynhyrchu papur rhychiog a bwrdd papur, sachau a bagiau		
-17219	17210	Manufacture of other paper and paperboard containers	Gweithgynhyrchu cynwysyddion eraill o bapur a bwrdd papur		
-17220	172	Manufacture of household and sanitary goods and of toilet requisites	Gweithgynhyrchu nwyddau cartref, iechydol a thŷ bach		
-17230	172	Manufacture of paper stationery	Gweithgynhyrchu deunyddiau ysgrifennu papur		
-17240	172	Manufacture of wallpaper	Gweithgynhyrchu papur wal		
-17290	172	Manufacture of other articles of paper and paperboard not elsewhere classified	Gweithgynhyrchu eitemau eraill o bapur a bwrdd papur n.dd.b.		
+17.1	17	Manufacture of pulp, paper and paperboard			
+17.11	17.1	Manufacture of pulp	Gweithgynhyrchu mwydion pren		
+17.12	17.1	Manufacture of paper and paperboard	Gweithgynhyrchu papur a bwrdd papur		
+17.2	17	Manufacture of articles of paper and paperboard			
+17.21	17.2	Manufacture of corrugated paper and paperboard and of containers of paper and paperboard			
+17.21/1	17.21	Manufacture of corrugated paper and paperboard, sacks and bags	Gweithgynhyrchu papur rhychiog a bwrdd papur, sachau a bagiau		
+17.21/9	17.21	Manufacture of other paper and paperboard containers	Gweithgynhyrchu cynwysyddion eraill o bapur a bwrdd papur		
+17.22	17.2	Manufacture of household and sanitary goods and of toilet requisites	Gweithgynhyrchu nwyddau cartref, iechydol a thŷ bach		
+17.23	17.2	Manufacture of paper stationery	Gweithgynhyrchu deunyddiau ysgrifennu papur		
+17.24	17.2	Manufacture of wallpaper	Gweithgynhyrchu papur wal		
+17.29	17.2	Manufacture of other articles of paper and paperboard not elsewhere classified	Gweithgynhyrchu eitemau eraill o bapur a bwrdd papur n.dd.b.		
 18	C	Printing and reproduction of recorded media			
-181	18	Printing and service activities related to printing			
-18110	181	Printing of newspapers	Argraffu papurau newydd		
-18120	181	Other printing			
-18121	18120	Manufacture of printed labels	Gweithgynhyrchu labeli printiedig		
-18129	18120	Printing not elsewhere classified	Argraffu n.dd.b.		
-18130	181	Pre-press and pre-media services	Gwasanaethau paratoi ar gyfer y wasg a'r cyfryngau		
-18140	181	Binding and related services	Rhwymo a gwasanaethau cysylltiedig		
-182	18	Reproduction of recorded media			
-18200	182	Reproduction of recorded media			
-18201	18200	Reproduction of sound recording	Atgynhyrchu recordiadau sain		
-18202	18200	Reproduction of video recording	Atgynhyrchu recordiadau fideo		
-18203	18200	Reproduction of computer media	Atgynhyrchu cyfryngau cyfrifiadurol		
+18.1	18	Printing and service activities related to printing			
+18.11	18.1	Printing of newspapers	Argraffu papurau newydd		
+18.12	18.1	Other printing			
+18.12/1	18.12	Manufacture of printed labels	Gweithgynhyrchu labeli printiedig		
+18.12/9	18.12	Printing not elsewhere classified	Argraffu n.dd.b.		
+18.13	18.1	Pre-press and pre-media services	Gwasanaethau paratoi ar gyfer y wasg a'r cyfryngau		
+18.14	18.1	Binding and related services	Rhwymo a gwasanaethau cysylltiedig		
+18.2	18	Reproduction of recorded media			
+18.20	18.2	Reproduction of recorded media			
+18.20/1	18.20	Reproduction of sound recording	Atgynhyrchu recordiadau sain		
+18.20/2	18.20	Reproduction of video recording	Atgynhyrchu recordiadau fideo		
+18.20/3	18.20	Reproduction of computer media	Atgynhyrchu cyfryngau cyfrifiadurol		
 19	C	Manufacture of coke and refined petroleum products			
-191	19	Manufacture of coke oven products			
-19100	191	Manufacture of coke oven products	Gweithgynhyrchu cynhyrchion ffwrn golosg		
-192	19	Manufacture of refined petroleum products			
-19200	192	Manufacture of refined petroleum products			
-19201	19200	Mineral oil refining	Puro olewon mwynol		
-19209	19200	Other treatment of petroleum products (excluding petrochemicals manufacture)	Trin cynhyrchion petrolewm eraill (ac eithrio gweithgynhyrchu petrocemegion)		
+19.1	19	Manufacture of coke oven products			
+19.10	19.1	Manufacture of coke oven products	Gweithgynhyrchu cynhyrchion ffwrn golosg		
+19.2	19	Manufacture of refined petroleum products			
+19.20	19.2	Manufacture of refined petroleum products			
+19.20/1	19.20	Mineral oil refining	Puro olewon mwynol		
+19.20/9	19.20	Other treatment of petroleum products (excluding petrochemicals manufacture)	Trin cynhyrchion petrolewm eraill (ac eithrio gweithgynhyrchu petrocemegion)		
 20	C	Manufacture of chemicals and chemical products			
-201	20	Manufacture of basic chemicals, fertilisers and nitrogen compounds, plastics and synthetic rubber in primary forms			
-20110	201	Manufacture of industrial gases	Gweithgynhyrchu nwyon diwydiannol		
-20120	201	Manufacture of dyes and pigments	Gweithgynhyrchu lifynnau a phigmentau		
-20130	201	Manufacture of other inorganic basic chemicals	Gweithgynhyrchu cemegion sylfaenol anorganig eraill		
-20140	201	Manufacture of other organic basic chemicals	Gweithgynhyrchu cemegion sylfaenol organig eraill		
-20150	201	Manufacture of fertilizers and nitrogen compounds	Gweithgynhyrchu gwrtaith a chyfansoddion nitrogen		
-20160	201	Manufacture of plastics in primary forms	Gweithgynhyrchu plastig ar ei ffurf sylfaenol		
-20170	201	Manufacture of synthetic rubber in primary forms	Gweithgynhyrchu rwber synthetig ar ei ffurf sylfaenol		
-202	20	Manufacture of pesticides and other agrochemical products			
-20200	202	Manufacture of pesticides and other agrochemical products	Gweithgynhyrchu plaladdwyr a chynnyrch agrocemegol		
-203	20	Manufacture of paints, varnishes and similar coatings, printing ink and mastics			
-20300	203	Manufacture of paints, varnishes and similar coatings, printing ink and mastics			
-20301	20300	Manufacture of paints, varnishes and similar coatings, mastics and sealants	Gweithgynhyrchu paent, farnais a chaenau, mastigau a deunyddiau selio tebyg eraill		
-20302	20300	Manufacture of printing ink	Gweithgynhyrchu inc argraffu		
-204	20	Manufacture of soap and detergents, cleaning and polishing preparations, perfumes and toilet preparations			
-20410	204	Manufacture of soap and detergents, cleaning and polishing preparations			
-20411	20410	Manufacture of soap and detergents	Gweithgynhyrchu sebon a glanedyddion		
-20412	20410	Manufacture of cleaning and polishing preparations	Gweithgynhyrchu cymysgeddau glanhau a chaboli		
-20420	204	Manufacture of perfumes and toilet preparations	Gweithgynhyrchu persawrau a chymysgeddau ymolchi		
-205	20	Manufacture of other chemical products			
-20510	205	Manufacture of explosives	Gweithgynhyrchu ffrwydron		
-20520	205	Manufacture of glues	Gweithgynhyrchu glud		
-20530	205	Manufacture of essential oils	Gweithgynhyrchu olewon naws		
-20590	205	Manufacture of other chemical products not elsewhere classified	Gweithgynhyrchu cynhyrchion cemegol eraill n.dd.b.		
-206	20	Manufacture of man-made fibres			
-20600	206	Manufacture of man-made fibres	Gweithgynhyrchu ffibrau gwneud		
+20.1	20	Manufacture of basic chemicals, fertilisers and nitrogen compounds, plastics and synthetic rubber in primary forms			
+20.11	20.1	Manufacture of industrial gases	Gweithgynhyrchu nwyon diwydiannol		
+20.12	20.1	Manufacture of dyes and pigments	Gweithgynhyrchu lifynnau a phigmentau		
+20.13	20.1	Manufacture of other inorganic basic chemicals	Gweithgynhyrchu cemegion sylfaenol anorganig eraill		
+20.14	20.1	Manufacture of other organic basic chemicals	Gweithgynhyrchu cemegion sylfaenol organig eraill		
+20.15	20.1	Manufacture of fertilizers and nitrogen compounds	Gweithgynhyrchu gwrtaith a chyfansoddion nitrogen		
+20.16	20.1	Manufacture of plastics in primary forms	Gweithgynhyrchu plastig ar ei ffurf sylfaenol		
+20.17	20.1	Manufacture of synthetic rubber in primary forms	Gweithgynhyrchu rwber synthetig ar ei ffurf sylfaenol		
+20.2	20	Manufacture of pesticides and other agrochemical products			
+20.20	20.2	Manufacture of pesticides and other agrochemical products	Gweithgynhyrchu plaladdwyr a chynnyrch agrocemegol		
+20.3	20	Manufacture of paints, varnishes and similar coatings, printing ink and mastics			
+20.30	20.3	Manufacture of paints, varnishes and similar coatings, printing ink and mastics			
+20.30/1	20.30	Manufacture of paints, varnishes and similar coatings, mastics and sealants	Gweithgynhyrchu paent, farnais a chaenau, mastigau a deunyddiau selio tebyg eraill		
+20.30/2	20.30	Manufacture of printing ink	Gweithgynhyrchu inc argraffu		
+20.4	20	Manufacture of soap and detergents, cleaning and polishing preparations, perfumes and toilet preparations			
+20.41	20.4	Manufacture of soap and detergents, cleaning and polishing preparations			
+20.41/1	20.41	Manufacture of soap and detergents	Gweithgynhyrchu sebon a glanedyddion		
+20.41/2	20.41	Manufacture of cleaning and polishing preparations	Gweithgynhyrchu cymysgeddau glanhau a chaboli		
+20.42	20.4	Manufacture of perfumes and toilet preparations	Gweithgynhyrchu persawrau a chymysgeddau ymolchi		
+20.5	20	Manufacture of other chemical products			
+20.51	20.5	Manufacture of explosives	Gweithgynhyrchu ffrwydron		
+20.52	20.5	Manufacture of glues	Gweithgynhyrchu glud		
+20.53	20.5	Manufacture of essential oils	Gweithgynhyrchu olewon naws		
+20.59	20.5	Manufacture of other chemical products not elsewhere classified	Gweithgynhyrchu cynhyrchion cemegol eraill n.dd.b.		
+20.6	20	Manufacture of man-made fibres			
+20.60	20.6	Manufacture of man-made fibres	Gweithgynhyrchu ffibrau gwneud		
 21	C	Manufacture of basic pharmaceutical products and pharmaceutical preparations			
-211	21	Manufacture of basic pharmaceutical products			
-21100	211	Manufacture of basic pharmaceutical products	Gweithgynhyrchu cynhyrchion fferyllol sylfaenol		
-212	21	Manufacture of pharmaceutical preparations			
-21200	212	Manufacture of pharmaceutical preparations	Gweithgynhyrchu cymysgeddau fferyllol		
+21.1	21	Manufacture of basic pharmaceutical products			
+21.10	21.1	Manufacture of basic pharmaceutical products	Gweithgynhyrchu cynhyrchion fferyllol sylfaenol		
+21.2	21	Manufacture of pharmaceutical preparations			
+21.20	21.2	Manufacture of pharmaceutical preparations	Gweithgynhyrchu cymysgeddau fferyllol		
 22	C	Manufacture of rubber and plastic products			
-221	22	Manufacture of rubber products			
-22110	221	Manufacture of rubber tyres and tubes; retreading and rebuilding of rubber tyres	Gweithgynhyrchu teiars a thiwbiau rwber; adfer ac ailwampio teiars rwber		
-22190	221	Manufacture of other rubber products	Gweithgynhyrchu cynhyrchion rwber eraill		
-222	22	Manufacture of plastics products			
-22210	222	Manufacture of plastic plates, sheets, tubes and profiles	Gweithgynhyrchu platiau, dalenni, tiwbiau a phroffiliau plastig		
-22220	222	Manufacture of plastic packing goods	Gweithgynhyrchu nwyddau pacio plastig		
-22230	222	Manufacture of builders  ware of plastic	Gweithgynhyrchu deunydd adeiladu o blastig		
-22290	222	Manufacture of other plastic products	Gweithgynhyrchu cynhyrchion plastig eraill		
+22.1	22	Manufacture of rubber products			
+22.11	22.1	Manufacture of rubber tyres and tubes; retreading and rebuilding of rubber tyres	Gweithgynhyrchu teiars a thiwbiau rwber; adfer ac ailwampio teiars rwber		
+22.19	22.1	Manufacture of other rubber products	Gweithgynhyrchu cynhyrchion rwber eraill		
+22.2	22	Manufacture of plastics products			
+22.21	22.2	Manufacture of plastic plates, sheets, tubes and profiles	Gweithgynhyrchu platiau, dalenni, tiwbiau a phroffiliau plastig		
+22.22	22.2	Manufacture of plastic packing goods	Gweithgynhyrchu nwyddau pacio plastig		
+22.23	22.2	Manufacture of builders  ware of plastic	Gweithgynhyrchu deunydd adeiladu o blastig		
+22.29	22.2	Manufacture of other plastic products	Gweithgynhyrchu cynhyrchion plastig eraill		
 23	C	Manufacture of other non-metallic mineral products			
-231	23	Manufacture of glass and glass products			
-23110	231	Manufacture of flat glass	Gweithgynhyrchu gwydr gwastad		
-23120	231	Shaping and processing of flat glass	Siapio a phrosesu gwydr gwastad		
-23130	231	Manufacture of hollow glass	Gweithgynhyrchu gwydr cau		
-23140	231	Manufacture of glass fibres	Gweithgynhyrchu ffibrau gwydr		
-23190	231	Manufacture and processing of other glass, including technical glassware	Gweithgynhyrchu a phrosesu gwydrau eraill, gan gynnwys llestri gwydr technegol		
-232	23	Manufacture of refractory products			
-23200	232	Manufacture of refractory products	Gweithgynhyrchu cynhyrchion gwrthsafol		
-233	23	Manufacture of clay building materials			
-23310	233	Manufacture of ceramic tiles and flags	Gweithgynhyrchu teils a cherrig llorio serameg		
-23320	233	Manufacture of bricks, tiles and construction products, in baked clay	Gweithgynhyrchu brics, teils a chynhyrchion adeiladu clai cras		
-234	23	Manufacture of other porcelain and ceramic products			
-23410	234	Manufacture of ceramic household and ornamental articles	Gweithgynhyrchu nwyddau cartref ac addurnol seramig		
-23420	234	Manufacture of ceramic sanitary fixtures	Gweithgynhyrchu offer iechydol seramig		
-23430	234	Manufacture of ceramic insulators and insulating fittings	Gweithgynhyrchu ynysyddion ac offer ynysu seramig		
-23440	234	Manufacture of other technical ceramic products	Gweithgynhyrchu cynhyrchion technegol seramig eraill		
-23490	234	Manufacture of other ceramic products not elsewhere classified	Gweithgynhyrchu cynhyrchion seramig eraill n.dd.b.		
-235	23	Manufacture of cement, lime and plaster			
-23510	235	Manufacture of cement	Gweithgynhyrchu sment		
-23520	235	Manufacture of lime and plaster	Gweithgynhyrchu calch a phlastr		
-236	23	Manufacture of articles of concrete, cement and plaster			
-23610	236	Manufacture of concrete products for construction purposes	Gweithgynhyrchu cynhyrchion concrit at ddibenion adeiladu		
-23620	236	Manufacture of plaster products for construction purposes	Gweithgynhyrchu cynhyrchion plastr at ddibenion adeiladu		
-23630	236	Manufacture of ready-mixed concrete	Gweithgynhyrchu concrit parod		
-23640	236	Manufacture of mortars	Gweithgynhyrchu morter (priddgalch)		
-23650	236	Manufacture of fibre cement	Gweithgynhyrchu sment ffibr		
-23690	236	Manufacture of other articles of concrete, plaster and cement	Gweithgynhyrchu nwyddau eraill o goncrit, plastr a sment		
-237	23	Cutting, shaping and finishing of stone			
-23700	237	Cutting, shaping and finishing of stone	Torri, naddu a gorffennu carreg		
-239	23	Manufacture of abrasive products and non-metallic mineral products not elsewhere classified			
-23910	239	Production of abrasive products	Cynhyrchu cynhyrchion ffrithiol		
-23990	239	Manufacture of other non-metallic mineral products not elsewhere classified	Gweithgynhyrchu cynhyrchion mwynau anfetelaidd eraill n.dd.b.		
+23.1	23	Manufacture of glass and glass products			
+23.11	23.1	Manufacture of flat glass	Gweithgynhyrchu gwydr gwastad		
+23.12	23.1	Shaping and processing of flat glass	Siapio a phrosesu gwydr gwastad		
+23.13	23.1	Manufacture of hollow glass	Gweithgynhyrchu gwydr cau		
+23.14	23.1	Manufacture of glass fibres	Gweithgynhyrchu ffibrau gwydr		
+23.19	23.1	Manufacture and processing of other glass, including technical glassware	Gweithgynhyrchu a phrosesu gwydrau eraill, gan gynnwys llestri gwydr technegol		
+23.2	23	Manufacture of refractory products			
+23.20	23.2	Manufacture of refractory products	Gweithgynhyrchu cynhyrchion gwrthsafol		
+23.3	23	Manufacture of clay building materials			
+23.31	23.3	Manufacture of ceramic tiles and flags	Gweithgynhyrchu teils a cherrig llorio serameg		
+23.32	23.3	Manufacture of bricks, tiles and construction products, in baked clay	Gweithgynhyrchu brics, teils a chynhyrchion adeiladu clai cras		
+23.4	23	Manufacture of other porcelain and ceramic products			
+23.41	23.4	Manufacture of ceramic household and ornamental articles	Gweithgynhyrchu nwyddau cartref ac addurnol seramig		
+23.42	23.4	Manufacture of ceramic sanitary fixtures	Gweithgynhyrchu offer iechydol seramig		
+23.43	23.4	Manufacture of ceramic insulators and insulating fittings	Gweithgynhyrchu ynysyddion ac offer ynysu seramig		
+23.44	23.4	Manufacture of other technical ceramic products	Gweithgynhyrchu cynhyrchion technegol seramig eraill		
+23.49	23.4	Manufacture of other ceramic products not elsewhere classified	Gweithgynhyrchu cynhyrchion seramig eraill n.dd.b.		
+23.5	23	Manufacture of cement, lime and plaster			
+23.51	23.5	Manufacture of cement	Gweithgynhyrchu sment		
+23.52	23.5	Manufacture of lime and plaster	Gweithgynhyrchu calch a phlastr		
+23.6	23	Manufacture of articles of concrete, cement and plaster			
+23.61	23.6	Manufacture of concrete products for construction purposes	Gweithgynhyrchu cynhyrchion concrit at ddibenion adeiladu		
+23.62	23.6	Manufacture of plaster products for construction purposes	Gweithgynhyrchu cynhyrchion plastr at ddibenion adeiladu		
+23.63	23.6	Manufacture of ready-mixed concrete	Gweithgynhyrchu concrit parod		
+23.64	23.6	Manufacture of mortars	Gweithgynhyrchu morter (priddgalch)		
+23.65	23.6	Manufacture of fibre cement	Gweithgynhyrchu sment ffibr		
+23.69	23.6	Manufacture of other articles of concrete, plaster and cement	Gweithgynhyrchu nwyddau eraill o goncrit, plastr a sment		
+23.7	23	Cutting, shaping and finishing of stone			
+23.70	23.7	Cutting, shaping and finishing of stone	Torri, naddu a gorffennu carreg		
+23.9	23	Manufacture of abrasive products and non-metallic mineral products not elsewhere classified			
+23.91	23.9	Production of abrasive products	Cynhyrchu cynhyrchion ffrithiol		
+23.99	23.9	Manufacture of other non-metallic mineral products not elsewhere classified	Gweithgynhyrchu cynhyrchion mwynau anfetelaidd eraill n.dd.b.		
 24	C	Manufacture of basic metals			
-241	24	Manufacture of basic iron and steel and of ferro-alloys			
-24100	241	Manufacture of basic iron and steel and of ferro-alloys	Gweithgynhyrchu haearn a dur sylfaenol a ffero-aloeon		
-242	24	Manufacture of tubes, pipes, hollow profiles and related fittings, of steel			
-24200	242	Manufacture of tubes, pipes, hollow profiles and related fittings, of steel	Gweithgynhyrchu tiwbiau, pibellau, proffiliau gwag a gosodiadau cysylltiedig, o ddur		
-243	24	Manufacture of other products of first processing of steel			
-24310	243	Cold drawing of bars	Tynnu bariau yn oer		
-24320	243	Cold rolling of narrow strip	Rholio stribedi cul yn oer		
-24330	243	Cold forming or folding	Ffurfio neu blygu oer		
-24340	243	Cold drawing of wire	Tynnu weiar yn oer		
-244	24	Manufacture of basic precious and other non-ferrous metals			
-24410	244	Precious metals production	Cynhyrchu metelau gwerthfawr		
-24420	244	Aluminium production	Cynhyrchu alwminiwm		
-24430	244	Lead, zinc and tin production	Cynhyrchu plwm, sinc a thun		
-24440	244	Copper production	Cynhyrchu copr		
-24450	244	Other non-ferrous metal production	Cynhyrchu metelau anfferrus eraill		
-24460	244	Processing of nuclear fuel	Prosesu tanwydd niwclear		
-245	24	Casting of metals			
-24510	245	Casting of iron	Bwrw haearn		
-24520	245	Casting of steel	Bwrw dur		
-24530	245	Casting of light metals	Bwrw metelau ysgafn		
-24540	245	Casting of other non-ferrous metals	Bwrw metelau anfferrus eraill		
+24.1	24	Manufacture of basic iron and steel and of ferro-alloys			
+24.10	24.1	Manufacture of basic iron and steel and of ferro-alloys	Gweithgynhyrchu haearn a dur sylfaenol a ffero-aloeon		
+24.2	24	Manufacture of tubes, pipes, hollow profiles and related fittings, of steel			
+24.20	24.2	Manufacture of tubes, pipes, hollow profiles and related fittings, of steel	Gweithgynhyrchu tiwbiau, pibellau, proffiliau gwag a gosodiadau cysylltiedig, o ddur		
+24.3	24	Manufacture of other products of first processing of steel			
+24.31	24.3	Cold drawing of bars	Tynnu bariau yn oer		
+24.32	24.3	Cold rolling of narrow strip	Rholio stribedi cul yn oer		
+24.33	24.3	Cold forming or folding	Ffurfio neu blygu oer		
+24.34	24.3	Cold drawing of wire	Tynnu weiar yn oer		
+24.4	24	Manufacture of basic precious and other non-ferrous metals			
+24.41	24.4	Precious metals production	Cynhyrchu metelau gwerthfawr		
+24.42	24.4	Aluminium production	Cynhyrchu alwminiwm		
+24.43	24.4	Lead, zinc and tin production	Cynhyrchu plwm, sinc a thun		
+24.44	24.4	Copper production	Cynhyrchu copr		
+24.45	24.4	Other non-ferrous metal production	Cynhyrchu metelau anfferrus eraill		
+24.46	24.4	Processing of nuclear fuel	Prosesu tanwydd niwclear		
+24.5	24	Casting of metals			
+24.51	24.5	Casting of iron	Bwrw haearn		
+24.52	24.5	Casting of steel	Bwrw dur		
+24.53	24.5	Casting of light metals	Bwrw metelau ysgafn		
+24.54	24.5	Casting of other non-ferrous metals	Bwrw metelau anfferrus eraill		
 25	C	Manufacture of fabricated metal products, except machinery and equipment			
-251	25	Manufacture of structural metal products			
-25110	251	Manufacture of metal structures and parts of structures	Gweithgynhyrchu strwythurau metel a rhannau o strwythurau		
-25120	251	Manufacture of doors and windows of metal	Gweithgynhyrchu drysau a ffenestri o fetel		
-252	25	Manufacture of tanks, reservoirs and containers of metal			
-25210	252	Manufacture of central heating radiators and boilers	Gweithgynhyrchu rheiddiaduron a bwyleri gwres canolog		
-25290	252	Manufacture of other tanks, reservoirs and containers of metal	Gweithgynhyrchu tanciau, cronfeydd a chynwysyddion eraill o fetel		
-253	25	Manufacture of steam generators, except central heating hot water boilers			
-25300	253	Manufacture of steam generators, except central heating hot water boilers	Gweithgynhyrchu generaduron stêm, ac eithrio bwyleri dŵr poeth gwres canolog		
-254	25	Manufacture of weapons and ammunition			
-25400	254	Manufacture of weapons and ammunition	Gweithgynhyrchu arfau a ffrwydron rhyfel		
-255	25	Forging, pressing, stamping and roll-forming of metal; powder metallurgy			
-25500	255	Forging, pressing, stamping and roll-forming of metal; powder metallurgy	Gofannu, gwasgu, stampio a rholio metel; meteleg powdr		
-256	25	Treatment and coating of metals; machining			
-25610	256	Treatment and coating of metals	Trin a chaenu metelau		
-25620	256	Machining	Turnio		
-257	25	Manufacture of cutlery, tools and general hardware			
-25710	257	Manufacture of cutlery	Gweithgynhyrchu cytleri		
-25720	257	Manufacture of locks and hinges	Gweithgynhyrchu cloeon a cholfachau		
-25730	257	Manufacture of tools	Gweithgynhyrchu tŵls		
-259	25	Manufacture of other fabricated metal products			
-25910	259	Manufacture of steel drums and similar containers	Gweithgynhyrchu drymiau dur a chynwysyddion tebyg		
-25920	259	Manufacture of light metal packaging	Gweithgynhyrchu deunydd pecynnu metel ysgafn		
-25930	259	Manufacture of wire products, chain and springs	Gweithgynhyrchu cynhyrchion weiar, cadwyni a sbringiau		
-25940	259	Manufacture of fasteners and screw machine products	Gweithgynhyrchu ffasnyddion a sgriwiau peiriannol		
-25990	259	Manufacture of other fabricated metal products not elsewhere classified	Gweithgynhyrchu cynhyrchion metel gwneud eraill n.dd.b.		
+25.1	25	Manufacture of structural metal products			
+25.11	25.1	Manufacture of metal structures and parts of structures	Gweithgynhyrchu strwythurau metel a rhannau o strwythurau		
+25.12	25.1	Manufacture of doors and windows of metal	Gweithgynhyrchu drysau a ffenestri o fetel		
+25.2	25	Manufacture of tanks, reservoirs and containers of metal			
+25.21	25.2	Manufacture of central heating radiators and boilers	Gweithgynhyrchu rheiddiaduron a bwyleri gwres canolog		
+25.29	25.2	Manufacture of other tanks, reservoirs and containers of metal	Gweithgynhyrchu tanciau, cronfeydd a chynwysyddion eraill o fetel		
+25.3	25	Manufacture of steam generators, except central heating hot water boilers			
+25.30	25.3	Manufacture of steam generators, except central heating hot water boilers	Gweithgynhyrchu generaduron stêm, ac eithrio bwyleri dŵr poeth gwres canolog		
+25.4	25	Manufacture of weapons and ammunition			
+25.40	25.4	Manufacture of weapons and ammunition	Gweithgynhyrchu arfau a ffrwydron rhyfel		
+25.5	25	Forging, pressing, stamping and roll-forming of metal; powder metallurgy			
+25.50	25.5	Forging, pressing, stamping and roll-forming of metal; powder metallurgy	Gofannu, gwasgu, stampio a rholio metel; meteleg powdr		
+25.6	25	Treatment and coating of metals; machining			
+25.61	25.6	Treatment and coating of metals	Trin a chaenu metelau		
+25.62	25.6	Machining	Turnio		
+25.7	25	Manufacture of cutlery, tools and general hardware			
+25.71	25.7	Manufacture of cutlery	Gweithgynhyrchu cytleri		
+25.72	25.7	Manufacture of locks and hinges	Gweithgynhyrchu cloeon a cholfachau		
+25.73	25.7	Manufacture of tools	Gweithgynhyrchu tŵls		
+25.9	25	Manufacture of other fabricated metal products			
+25.91	25.9	Manufacture of steel drums and similar containers	Gweithgynhyrchu drymiau dur a chynwysyddion tebyg		
+25.92	25.9	Manufacture of light metal packaging	Gweithgynhyrchu deunydd pecynnu metel ysgafn		
+25.93	25.9	Manufacture of wire products, chain and springs	Gweithgynhyrchu cynhyrchion weiar, cadwyni a sbringiau		
+25.94	25.9	Manufacture of fasteners and screw machine products	Gweithgynhyrchu ffasnyddion a sgriwiau peiriannol		
+25.99	25.9	Manufacture of other fabricated metal products not elsewhere classified	Gweithgynhyrchu cynhyrchion metel gwneud eraill n.dd.b.		
 26	C	Manufacture of computer, electronic and optical products			
-261	26	Manufacture of electronic components and boards			
-26110	261	Manufacture of electronic components	Gweithgynhyrchu cydrannau electronig		
-26120	261	Manufacture of loaded electronic boards	Gweithgynhyrchu byrddau electronig parod		
-262	26	Manufacture of computers and peripheral equipment			
-26200	262	Manufacture of computers and peripheral equipment	Gweithgynhyrchu cyfrifiaduron a pherifferolion		
-263	26	Manufacture of communication equipment			
-26300	263	Manufacture of communication equipment			
-26301	26300	Manufacture of telegraph and telephone apparatus and equipment	Gweithgynhyrchu cyfarpar ac offer telegraff a theleffon		
-26309	26300	Manufacture of communication equipment other than telegraph, and telephone apparatus and equipment	Gweithgynhyrchu offer a chyfarpar cyfathrebu ac eithrio cyfarpar ac offer telegraff a theleffon		
-264	26	Manufacture of consumer electronics			
-26400	264	Manufacture of consumer electronics	Gweithgynhyrchu electroneg i ddefnyddwyr		
-265	26	Manufacture of instruments and appliances for measuring, testing and navigation; watches and clocks			
-26510	265	Manufacture of instruments and appliances for measuring, testing and navigation			
-26511	26510	Manufacture of electronic measuring, testing etc. equipment, not for industrial process control	Gweithgynhyrchu cyfarpar electronig ar gyfer mesur, profi ac ati, ond nid at ddibenion rheoli prosesau diwydiannol		
-26512	26510	Manufacture of electronic industrial process control equipment	Gweithgynhyrchu cyfarpar electronig i reoli prosesau diwydiannol		
-26513	26510	Manufacture of non-electronic measuring, testing etc. equipment, not for industrial process control	Gweithgynhyrchu cyfarpar nad yw'n electronig ar gyfer mesur, profi ac ati, ond nid at ddibenion rheoli prosesau diwydiannol		
-26514	26510	Manufacture of non-electronic industrial process control equipment	Gweithgynhyrchu cyfarpar nad yw'n electronig ar gyfer rheoli prosesau diwydiannol		
-26520	265	Manufacture of watches and clocks	Gweithgynhyrchu watsys a chlociau		
-266	26	Manufacture of irradiation, electromedical and electrotherapeutic equipment			
-26600	266	Manufacture of irradiation, electromedical and electrotherapeutic equipment	Gweithgynhyrchu cyfarpar arbelydru, electrofeddygol ac electrotherapiwtig		
-267	26	Manufacture of optical instruments and photographic equipment			
-26700	267	Manufacture of optical instruments and photographic equipment			
-26701	26700	Manufacture of optical precision instruments	Gweithgynhyrchu cyfarpar manylwaith optig		
-26702	26700	Manufacture of photographic and cinematographic equipment	Gweithgynhyrchu cyfarpar ffotograffig a sinematograffig		
-268	26	Manufacture of magnetic and optical media			
-26800	268	Manufacture of magnetic and optical media	Gweithgynhyrchu cyfryngau magnetig ac optegol		
+26.1	26	Manufacture of electronic components and boards			
+26.11	26.1	Manufacture of electronic components	Gweithgynhyrchu cydrannau electronig		
+26.12	26.1	Manufacture of loaded electronic boards	Gweithgynhyrchu byrddau electronig parod		
+26.2	26	Manufacture of computers and peripheral equipment			
+26.20	26.2	Manufacture of computers and peripheral equipment	Gweithgynhyrchu cyfrifiaduron a pherifferolion		
+26.3	26	Manufacture of communication equipment			
+26.30	26.3	Manufacture of communication equipment			
+26.30/1	26.30	Manufacture of telegraph and telephone apparatus and equipment	Gweithgynhyrchu cyfarpar ac offer telegraff a theleffon		
+26.30/9	26.30	Manufacture of communication equipment other than telegraph, and telephone apparatus and equipment	Gweithgynhyrchu offer a chyfarpar cyfathrebu ac eithrio cyfarpar ac offer telegraff a theleffon		
+26.4	26	Manufacture of consumer electronics			
+26.40	26.4	Manufacture of consumer electronics	Gweithgynhyrchu electroneg i ddefnyddwyr		
+26.5	26	Manufacture of instruments and appliances for measuring, testing and navigation; watches and clocks			
+26.51	26.5	Manufacture of instruments and appliances for measuring, testing and navigation			
+26.51/1	26.51	Manufacture of electronic measuring, testing etc. equipment, not for industrial process control	Gweithgynhyrchu cyfarpar electronig ar gyfer mesur, profi ac ati, ond nid at ddibenion rheoli prosesau diwydiannol		
+26.51/2	26.51	Manufacture of electronic industrial process control equipment	Gweithgynhyrchu cyfarpar electronig i reoli prosesau diwydiannol		
+26.51/3	26.51	Manufacture of non-electronic measuring, testing etc. equipment, not for industrial process control	Gweithgynhyrchu cyfarpar nad yw'n electronig ar gyfer mesur, profi ac ati, ond nid at ddibenion rheoli prosesau diwydiannol		
+26.51/4	26.51	Manufacture of non-electronic industrial process control equipment	Gweithgynhyrchu cyfarpar nad yw'n electronig ar gyfer rheoli prosesau diwydiannol		
+26.52	26.5	Manufacture of watches and clocks	Gweithgynhyrchu watsys a chlociau		
+26.6	26	Manufacture of irradiation, electromedical and electrotherapeutic equipment			
+26.60	26.6	Manufacture of irradiation, electromedical and electrotherapeutic equipment	Gweithgynhyrchu cyfarpar arbelydru, electrofeddygol ac electrotherapiwtig		
+26.7	26	Manufacture of optical instruments and photographic equipment			
+26.70	26.7	Manufacture of optical instruments and photographic equipment			
+26.70/1	26.70	Manufacture of optical precision instruments	Gweithgynhyrchu cyfarpar manylwaith optig		
+26.70/2	26.70	Manufacture of photographic and cinematographic equipment	Gweithgynhyrchu cyfarpar ffotograffig a sinematograffig		
+26.8	26	Manufacture of magnetic and optical media			
+26.80	26.8	Manufacture of magnetic and optical media	Gweithgynhyrchu cyfryngau magnetig ac optegol		
 27	C	Manufacture of electrical equipment			
-271	27	Manufacture of electric motors, generators, transformers and electricity distribution and control apparatus			
-27110	271	Manufacture of electric motors, generators and transformers	Gweithgynhyrchu moduron trydan, generaduron a newidyddion		
-27120	271	Manufacture of electricity distribution and control apparatus	Gweithgynhyrchu cyfarpar dosbarthu a rheoli trydan		
-272	27	Manufacture of batteries and accumulators			
-27200	272	Manufacture of batteries and accumulators	Gweithgynhyrchu batris a chronaduron		
-273	27	Manufacture of wiring and wiring devices			
-27310	273	Manufacture of fibre optic cables	Gweithgynhyrchu ceblau ffibr optig		
-27320	273	Manufacture of other electronic and electric wires and cables	Gweithgynhyrchu gwifrau a cheblau electronig a thrydan eraill		
-27330	273	Manufacture of wiring devices	Gweithgynhyrchu dyfeisiau gwifro		
-274	27	Manufacture of electric lighting equipment			
-27400	274	Manufacture of electric lighting equipment	Gweithgynhyrchu offer goleuo trydanol		
-275	27	Manufacture of domestic appliances			
-27510	275	Manufacture of electric domestic appliances	Gweithgynhyrchu dyfeisiau trydan domestig		
-27520	275	Manufacture of non-electric domestic appliances	Gweithgynhyrchu dyfeisiau domestig nad ydynt yn drydanol		
-279	27	Manufacture of other electrical equipment			
-27900	279	Manufacture of other electrical equipment	Gweithgynhyrchu cyfarpar trydanol eraill		
+27.1	27	Manufacture of electric motors, generators, transformers and electricity distribution and control apparatus			
+27.11	27.1	Manufacture of electric motors, generators and transformers	Gweithgynhyrchu moduron trydan, generaduron a newidyddion		
+27.12	27.1	Manufacture of electricity distribution and control apparatus	Gweithgynhyrchu cyfarpar dosbarthu a rheoli trydan		
+27.2	27	Manufacture of batteries and accumulators			
+27.20	27.2	Manufacture of batteries and accumulators	Gweithgynhyrchu batris a chronaduron		
+27.3	27	Manufacture of wiring and wiring devices			
+27.31	27.3	Manufacture of fibre optic cables	Gweithgynhyrchu ceblau ffibr optig		
+27.32	27.3	Manufacture of other electronic and electric wires and cables	Gweithgynhyrchu gwifrau a cheblau electronig a thrydan eraill		
+27.33	27.3	Manufacture of wiring devices	Gweithgynhyrchu dyfeisiau gwifro		
+27.4	27	Manufacture of electric lighting equipment			
+27.40	27.4	Manufacture of electric lighting equipment	Gweithgynhyrchu offer goleuo trydanol		
+27.5	27	Manufacture of domestic appliances			
+27.51	27.5	Manufacture of electric domestic appliances	Gweithgynhyrchu dyfeisiau trydan domestig		
+27.52	27.5	Manufacture of non-electric domestic appliances	Gweithgynhyrchu dyfeisiau domestig nad ydynt yn drydanol		
+27.9	27	Manufacture of other electrical equipment			
+27.90	27.9	Manufacture of other electrical equipment	Gweithgynhyrchu cyfarpar trydanol eraill		
 28	C	Manufacture of machinery and equipment not elsewhere classified			
-281	28	Manufacture of general-purpose machinery			
-28110	281	Manufacture of engines and turbines, except aircraft, vehicle and cycle engines	Gweithgynhyrchu injans a thyrbinau, ac eithrio injans awyrennau, cerbydau a beiciau		
-28120	281	Manufacture of fluid power equipment	Gweithgynhyrchu cyfarpar pŵer hylifol		
-28130	281	Manufacture of other pumps and compressors			
-28131	28130	Manufacture of pumps	Gweithgynhyrchu pympiau		
-28132	28130	Manufacture of compressors	Gweithgynhyrchu cywasgyddion		
-28140	281	Manufacture of taps and valves	Gweithgynhyrchu tapiau a falfiau		
-28150	281	Manufacture of bearings, gears, gearing and driving elements	Gweithgynhyrchu berynnau, gerau ac elfennau gerio a gyrru		
-282	28	Manufacture of other general-purpose machinery			
-28210	282	Manufacture of ovens, furnaces and furnace burners	Gweithgynhyrchu ffyrnau, ffwrneisi a llosgwyr ffwrnais		
-28220	282	Manufacture of lifting and handling equipment	Gweithgynhyrchu cyfarpar codi a thrin		
-28230	282	Manufacture of office machinery and equipment (except computers and peripheral equipment)	Gweithgynhyrchu peiriannau a chyfarpar swyddfa (ac eithrio cyfrifiaduron a pherifferolion)		
-28240	282	Manufacture of power-driven hand tools	Gweithgynhyrchu tŵls pŵer maint llaw		
-28250	282	Manufacture of non-domestic cooling and ventilation equipment	Gweithgynhyrchu offer oeri ac awyru annomestig		
-28290	282	Manufacture of other general-purpose machinery not elsewhere classified	Gweithgynhyrchu peiriannau eraill at ddibenion cyffredinol n.dd.b.		
-283	28	Manufacture of agricultural and forestry machinery			
-28300	283	Manufacture of agricultural and forestry machinery			
-28301	28300	Manufacture of agricultural tractors	Gweithgynhyrchu tractorau amaethyddol		
-28302	28300	Manufacture of agricultural and forestry machinery other than tractors	Gweithgynhyrchu peiriannau amaethyddol a choedwigaeth ac eithrio tractorau		
-284	28	Manufacture of metal forming machinery and machine tools			
-28410	284	Manufacture of metal forming machinery	Gweithgynhyrchu peiriannau ffurfio metel		
-28490	284	Manufacture of other machine tools	Gweithgynhyrchu offer peiriannol eraill		
-289	28	Manufacture of other special-purpose machinery			
-28910	289	Manufacture of machinery for metallurgy	Gweithgynhyrchu peiriannau meteleg		
-28920	289	Manufacture of machinery for mining, quarrying and construction			
-28921	28920	Manufacture of machinery for mining	Gweithgynhyrchu peiriannau mwyngloddio		
-28922	28920	Manufacture of earthmoving equipment	Gweithgynhyrchu cyfarpar symud tir		
-28923	28920	Manufacture of equipment for concrete crushing and screening and roadworks	Gweithgynhyrchu cyfarpar malu concrit a sgrinio a gwaith ffyrdd		
-28930	289	Manufacture of machinery for food, beverage and tobacco processing	Gweithgynhyrchu peiriannau prosesu bwyd, diodydd a thybaco		
-28940	289	Manufacture of machinery for textile, apparel and leather production	Gweithgynhyrchu peiriannau cynhyrchu tecstilau, dillad a lledr		
-28950	289	Manufacture of machinery for paper and paperboard production	Gweithgynhyrchu peiriannau cynhyrchu papur a bwrdd papur		
-28960	289	Manufacture of plastics and rubber machinery	Gweithgynhyrchu peiriannau gwneud plastig a rwber		
-28990	289	Manufacture of other special-purpose machinery not elsewhere classified	Gweithgynhyrchu peiriannau pwrpasol eraill n.dd.b.		
+28.1	28	Manufacture of general-purpose machinery			
+28.11	28.1	Manufacture of engines and turbines, except aircraft, vehicle and cycle engines	Gweithgynhyrchu injans a thyrbinau, ac eithrio injans awyrennau, cerbydau a beiciau		
+28.12	28.1	Manufacture of fluid power equipment	Gweithgynhyrchu cyfarpar pŵer hylifol		
+28.13	28.1	Manufacture of other pumps and compressors			
+28.13/1	28.13	Manufacture of pumps	Gweithgynhyrchu pympiau		
+28.13/2	28.13	Manufacture of compressors	Gweithgynhyrchu cywasgyddion		
+28.14	28.1	Manufacture of taps and valves	Gweithgynhyrchu tapiau a falfiau		
+28.15	28.1	Manufacture of bearings, gears, gearing and driving elements	Gweithgynhyrchu berynnau, gerau ac elfennau gerio a gyrru		
+28.2	28	Manufacture of other general-purpose machinery			
+28.21	28.2	Manufacture of ovens, furnaces and furnace burners	Gweithgynhyrchu ffyrnau, ffwrneisi a llosgwyr ffwrnais		
+28.22	28.2	Manufacture of lifting and handling equipment	Gweithgynhyrchu cyfarpar codi a thrin		
+28.23	28.2	Manufacture of office machinery and equipment (except computers and peripheral equipment)	Gweithgynhyrchu peiriannau a chyfarpar swyddfa (ac eithrio cyfrifiaduron a pherifferolion)		
+28.24	28.2	Manufacture of power-driven hand tools	Gweithgynhyrchu tŵls pŵer maint llaw		
+28.25	28.2	Manufacture of non-domestic cooling and ventilation equipment	Gweithgynhyrchu offer oeri ac awyru annomestig		
+28.29	28.2	Manufacture of other general-purpose machinery not elsewhere classified	Gweithgynhyrchu peiriannau eraill at ddibenion cyffredinol n.dd.b.		
+28.3	28	Manufacture of agricultural and forestry machinery			
+28.30	28.3	Manufacture of agricultural and forestry machinery			
+28.30/1	28.30	Manufacture of agricultural tractors	Gweithgynhyrchu tractorau amaethyddol		
+28.30/2	28.30	Manufacture of agricultural and forestry machinery other than tractors	Gweithgynhyrchu peiriannau amaethyddol a choedwigaeth ac eithrio tractorau		
+28.4	28	Manufacture of metal forming machinery and machine tools			
+28.41	28.4	Manufacture of metal forming machinery	Gweithgynhyrchu peiriannau ffurfio metel		
+28.49	28.4	Manufacture of other machine tools	Gweithgynhyrchu offer peiriannol eraill		
+28.9	28	Manufacture of other special-purpose machinery			
+28.91	28.9	Manufacture of machinery for metallurgy	Gweithgynhyrchu peiriannau meteleg		
+28.92	28.9	Manufacture of machinery for mining, quarrying and construction			
+28.92/1	28.92	Manufacture of machinery for mining	Gweithgynhyrchu peiriannau mwyngloddio		
+28.92/2	28.92	Manufacture of earthmoving equipment	Gweithgynhyrchu cyfarpar symud tir		
+28.92/3	28.92	Manufacture of equipment for concrete crushing and screening and roadworks	Gweithgynhyrchu cyfarpar malu concrit a sgrinio a gwaith ffyrdd		
+28.93	28.9	Manufacture of machinery for food, beverage and tobacco processing	Gweithgynhyrchu peiriannau prosesu bwyd, diodydd a thybaco		
+28.94	28.9	Manufacture of machinery for textile, apparel and leather production	Gweithgynhyrchu peiriannau cynhyrchu tecstilau, dillad a lledr		
+28.95	28.9	Manufacture of machinery for paper and paperboard production	Gweithgynhyrchu peiriannau cynhyrchu papur a bwrdd papur		
+28.96	28.9	Manufacture of plastics and rubber machinery	Gweithgynhyrchu peiriannau gwneud plastig a rwber		
+28.99	28.9	Manufacture of other special-purpose machinery not elsewhere classified	Gweithgynhyrchu peiriannau pwrpasol eraill n.dd.b.		
 29	C	Manufacture of motor vehicles, trailers and semi-trailers			
-291	29	Manufacture of motor vehicles			
-29100	291	Manufacture of motor vehicles	Gweithgynhyrchu cerbydau modur		
-292	29	Manufacture of bodies (coachwork) for motor vehicles; manufacture of trailers and semi-trailers			
-29200	292	Manufacture of bodies (coachwork) for motor vehicles; manufacture of trailers and semi-trailers			
-29201	29200	Manufacture of bodies (coachwork) for motor vehicles (except caravans)	Gweithgynhyrchu cyrff (coetswaith) cerbydau modur (ac eithrio carafanau)		
-29202	29200	Manufacture of trailers and semi-trailers	Gweithgynhyrchu trelars a hanner-trelars		
-29203	29200	Manufacture of caravans	Gweithgynhyrchu carafanau		
-293	29	Manufacture of parts and accessories for motor vehicles			
-29310	293	Manufacture of electrical and electronic equipment for motor vehicles and their engines	Gweithgynhyrchu cyfarpar trydanol ac electronig ar gyfer cerbydau modur a'u hinjans		
-29320	293	Manufacture of other parts and accessories for motor vehicles	Gweithgynhyrchu darnau ac ategolion eraill ar gyfer cerbydau modur		
+29.1	29	Manufacture of motor vehicles			
+29.10	29.1	Manufacture of motor vehicles	Gweithgynhyrchu cerbydau modur		
+29.2	29	Manufacture of bodies (coachwork) for motor vehicles; manufacture of trailers and semi-trailers			
+29.20	29.2	Manufacture of bodies (coachwork) for motor vehicles; manufacture of trailers and semi-trailers			
+29.20/1	29.20	Manufacture of bodies (coachwork) for motor vehicles (except caravans)	Gweithgynhyrchu cyrff (coetswaith) cerbydau modur (ac eithrio carafanau)		
+29.20/2	29.20	Manufacture of trailers and semi-trailers	Gweithgynhyrchu trelars a hanner-trelars		
+29.20/3	29.20	Manufacture of caravans	Gweithgynhyrchu carafanau		
+29.3	29	Manufacture of parts and accessories for motor vehicles			
+29.31	29.3	Manufacture of electrical and electronic equipment for motor vehicles and their engines	Gweithgynhyrchu cyfarpar trydanol ac electronig ar gyfer cerbydau modur a'u hinjans		
+29.32	29.3	Manufacture of other parts and accessories for motor vehicles	Gweithgynhyrchu darnau ac ategolion eraill ar gyfer cerbydau modur		
 30	C	Manufacture of other transport equipment			
-301	30	Building of ships and boats			
-30110	301	Building of ships and floating structures	Adeiladu llongau a strwythurau sy'n arnofio		
-30120	301	Building of pleasure and sporting boats	Adeiladu cychod pleser a chwaraeon		
-302	30	Manufacture of railway locomotives and rolling stock			
-30200	302	Manufacture of railway locomotives and rolling stock	Gweithgynhyrchu locomotifau a cherbydau rheilffordd		
-303	30	Manufacture of air and spacecraft and related machinery			
-30300	303	Manufacture of air and spacecraft and related machinery	Gweithgynhyrchu peiriannau awyr a llongau gofod a'r peiriannau cysylltiedig		
-304	30	Manufacture of military fighting vehicles			
-30400	304	Manufacture of military fighting vehicles	Gweithgynhyrchu cerbydau ymladd milwrol		
-309	30	Manufacture of transport equipment not elsewhere classified			
-30910	309	Manufacture of motorcycles	Gweithgynhyrchu beiciau modur		
-30920	309	Manufacture of bicycles and invalid carriages	Gweithgynhyrchu beiciau a cherbydau i'r methedig		
-30990	309	Manufacture of other transport equipment not elsewhere classified	Gweithgynhyrchu cyfarpar arall ar gyfer trafnidiaeth n.dd.b.		
+30.1	30	Building of ships and boats			
+30.11	30.1	Building of ships and floating structures	Adeiladu llongau a strwythurau sy'n arnofio		
+30.12	30.1	Building of pleasure and sporting boats	Adeiladu cychod pleser a chwaraeon		
+30.2	30	Manufacture of railway locomotives and rolling stock			
+30.20	30.2	Manufacture of railway locomotives and rolling stock	Gweithgynhyrchu locomotifau a cherbydau rheilffordd		
+30.3	30	Manufacture of air and spacecraft and related machinery			
+30.30	30.3	Manufacture of air and spacecraft and related machinery	Gweithgynhyrchu peiriannau awyr a llongau gofod a'r peiriannau cysylltiedig		
+30.4	30	Manufacture of military fighting vehicles			
+30.40	30.4	Manufacture of military fighting vehicles	Gweithgynhyrchu cerbydau ymladd milwrol		
+30.9	30	Manufacture of transport equipment not elsewhere classified			
+30.91	30.9	Manufacture of motorcycles	Gweithgynhyrchu beiciau modur		
+30.92	30.9	Manufacture of bicycles and invalid carriages	Gweithgynhyrchu beiciau a cherbydau i'r methedig		
+30.99	30.9	Manufacture of other transport equipment not elsewhere classified	Gweithgynhyrchu cyfarpar arall ar gyfer trafnidiaeth n.dd.b.		
 31	C	Manufacture of furniture			
-310	31	Manufacture of furniture			
-31010	310	Manufacture of office and shop furniture	Gweithgynhyrchu celfi swyddfa a siop		
-31020	310	Manufacture of kitchen furniture	Gweithgynhyrchu celfi'r gegin		
-31030	310	Manufacture of mattresses	Gweithgynhyrchu matresi		
-31090	310	Manufacture of other furniture	Gweithgynhyrchu celfi eraill		
+31.0	31	Manufacture of furniture			
+31.01	31.0	Manufacture of office and shop furniture	Gweithgynhyrchu celfi swyddfa a siop		
+31.02	31.0	Manufacture of kitchen furniture	Gweithgynhyrchu celfi'r gegin		
+31.03	31.0	Manufacture of mattresses	Gweithgynhyrchu matresi		
+31.09	31.0	Manufacture of other furniture	Gweithgynhyrchu celfi eraill		
 32	C	Other manufacturing			
-321	32	Manufacture of jewellery, bijouterie and related articles			
-32110	321	Striking of coins	Bwrw darnau arian		
-32120	321	Manufacture of jewellery and related articles	Gweithgynhyrchu gemwaith ac eitemau cysylltiedig		
-32130	321	Manufacture of imitation jewellery and related articles	Gweithgynhyrchu gemwaith ffug ac eitemau cysylltiedig		
-322	32	Manufacture of musical instruments			
-32200	322	Manufacture of musical instruments	Gweithgynhyrchu offerynnau cerdd		
-323	32	Manufacture of sports goods			
-32300	323	Manufacture of sports goods	Gweithgynhyrchu nwyddau chwaraeon		
-324	32	Manufacture of games and toys			
-32400	324	Manufacture of games and toys			
-32401	32400	Manufacture of professional and arcade games and toys	Gweithgynhyrchu gemau a theganau proffesiynol ac arcêd		
-32409	32400	Manufacture of other games and toys, not elsewhere classified	Gweithgynhyrchu gemau a theganau eraill n.dd.b.		
-325	32	Manufacture of medical and dental instruments and supplies			
-32500	325	Manufacture of medical and dental instruments and supplies	Gweithgynhyrchu offerynnau a nwyddau meddygol a deintyddol		
-329	32	Other manufacturing not elsewhere classified			
-32910	329	Manufacture of brooms and brushes	Gweithgynhyrchu ysgubellau a brwshys		
-32990	329	Other manufacturing not elsewhere classified	Gweithgynhyrchu arall n.dd.b.		
+32.1	32	Manufacture of jewellery, bijouterie and related articles			
+32.11	32.1	Striking of coins	Bwrw darnau arian		
+32.12	32.1	Manufacture of jewellery and related articles	Gweithgynhyrchu gemwaith ac eitemau cysylltiedig		
+32.13	32.1	Manufacture of imitation jewellery and related articles	Gweithgynhyrchu gemwaith ffug ac eitemau cysylltiedig		
+32.2	32	Manufacture of musical instruments			
+32.20	32.2	Manufacture of musical instruments	Gweithgynhyrchu offerynnau cerdd		
+32.3	32	Manufacture of sports goods			
+32.30	32.3	Manufacture of sports goods	Gweithgynhyrchu nwyddau chwaraeon		
+32.4	32	Manufacture of games and toys			
+32.40	32.4	Manufacture of games and toys			
+32.40/1	32.40	Manufacture of professional and arcade games and toys	Gweithgynhyrchu gemau a theganau proffesiynol ac arcêd		
+32.40/9	32.40	Manufacture of other games and toys, not elsewhere classified	Gweithgynhyrchu gemau a theganau eraill n.dd.b.		
+32.5	32	Manufacture of medical and dental instruments and supplies			
+32.50	32.5	Manufacture of medical and dental instruments and supplies	Gweithgynhyrchu offerynnau a nwyddau meddygol a deintyddol		
+32.9	32	Other manufacturing not elsewhere classified			
+32.91	32.9	Manufacture of brooms and brushes	Gweithgynhyrchu ysgubellau a brwshys		
+32.99	32.9	Other manufacturing not elsewhere classified	Gweithgynhyrchu arall n.dd.b.		
 33	C	Repair and installation of machinery and equipment			
-331	33	Repair of fabricated metal products, machinery and equipment			
-33110	331	Repair of fabricated metal products	Atgyweirio cynhyrchion metel gwneuthuredig		
-33120	331	Repair of machinery	Atgyweirio peiriannau		
-33130	331	Repair of electronic and optical equipment	Atgyweirio offer electronig ac optig		
-33140	331	Repair of electrical equipment	Atgyweirio offer trydanol		
-33150	331	Repair and maintenance of ships and boats	Atgyweirio a chynnal llongau a chychod		
-33160	331	Repair and maintenance of aircraft and spacecraft	Atgyweirio a chynnal awyrennau a llongau awyr		
-33170	331	Repair and maintenance of other transport equipment not elsewhere classified	Atgyweirio a chynnal of cyfarpar arall ar gyfer trafnidiaeth n.dd.b.		
-33190	331	Repair of other equipment	Atgyweirio mathau eraill o gyfarpar		
-332	33	Installation of industrial machinery and equipment			
-33200	332	Installation of industrial machinery and equipment	Gosod peiriannau ac offer diwydiannol		
+33.1	33	Repair of fabricated metal products, machinery and equipment			
+33.11	33.1	Repair of fabricated metal products	Atgyweirio cynhyrchion metel gwneuthuredig		
+33.12	33.1	Repair of machinery	Atgyweirio peiriannau		
+33.13	33.1	Repair of electronic and optical equipment	Atgyweirio offer electronig ac optig		
+33.14	33.1	Repair of electrical equipment	Atgyweirio offer trydanol		
+33.15	33.1	Repair and maintenance of ships and boats	Atgyweirio a chynnal llongau a chychod		
+33.16	33.1	Repair and maintenance of aircraft and spacecraft	Atgyweirio a chynnal awyrennau a llongau awyr		
+33.17	33.1	Repair and maintenance of other transport equipment not elsewhere classified	Atgyweirio a chynnal of cyfarpar arall ar gyfer trafnidiaeth n.dd.b.		
+33.19	33.1	Repair of other equipment	Atgyweirio mathau eraill o gyfarpar		
+33.2	33	Installation of industrial machinery and equipment			
+33.20	33.2	Installation of industrial machinery and equipment	Gosod peiriannau ac offer diwydiannol		
 35	D	Electricity, gas, steam and air conditioning supply			
-351	35	Electric power generation, transmission and distribution			
-35110	351	Production of electricity	Cynhyrchu trydan		
-35120	351	Transmission of electricity	Trawsyrru trydan		
-35130	351	Distribution of electricity	Dosbarthu trydan		
-35140	351	Trade of electricity	Masnachu trydan		
-352	35	Manufacture of gas; distribution of gaseous fuels through mains			
-35210	352	Manufacture of gas	Gweithgynhyrchu nwy		
-35220	352	Distribution of gaseous fuels through mains	Dosbarthu tanwydd nwyol trwy prif bibell		
-35230	352	Trade of gas through mains	Masnachu nwy trwy prif bibell		
-353	35	Steam and air conditioning supply			
-35300	353	Steam and air conditioning supply	Cyflenwi stêm a thymherwyr awyr		
+35.1	35	Electric power generation, transmission and distribution			
+35.11	35.1	Production of electricity	Cynhyrchu trydan		
+35.12	35.1	Transmission of electricity	Trawsyrru trydan		
+35.13	35.1	Distribution of electricity	Dosbarthu trydan		
+35.14	35.1	Trade of electricity	Masnachu trydan		
+35.2	35	Manufacture of gas; distribution of gaseous fuels through mains			
+35.21	35.2	Manufacture of gas	Gweithgynhyrchu nwy		
+35.22	35.2	Distribution of gaseous fuels through mains	Dosbarthu tanwydd nwyol trwy prif bibell		
+35.23	35.2	Trade of gas through mains	Masnachu nwy trwy prif bibell		
+35.3	35	Steam and air conditioning supply			
+35.30	35.3	Steam and air conditioning supply	Cyflenwi stêm a thymherwyr awyr		
 36	E	Water collection, treatment and supply			
-360	36	Water collection, treatment and supply			
-36000	360	Water collection, treatment and supply	Casglu, trin a chyflenwi dŵr		
+36.0	36	Water collection, treatment and supply			
+36.00	36.0	Water collection, treatment and supply	Casglu, trin a chyflenwi dŵr		
 37	E	Sewerage			
-370	37	Sewerage			
-37000	370	Sewerage	Carthffosiaeth		
+37.0	37	Sewerage			
+37.00	37.0	Sewerage	Carthffosiaeth		
 38	E	Waste collection, treatment and disposal activities; materials recovery			
-381	38	Waste collection			
-38110	381	Collection of non-hazardous waste	Casglu gwastraff nad yw'n beryglus		
-38120	381	Collection of hazardous waste	Casglu gwastraff peryglus		
-382	38	Waste treatment and disposal			
-38210	382	Treatment and disposal of non-hazardous waste	Trin a gwaredu gwastraff nad yw'n beryglus		
-38220	382	Treatment and disposal of hazardous waste	Trin a gwaredu gwastraff peryglus		
-383	38	Materials recovery			
-38310	383	Dismantling of wrecks	Datgymalu drylliadau		
-38320	383	Recovery of sorted materials	Adfer deunyddiau a ddidolwyd		
+38.1	38	Waste collection			
+38.11	38.1	Collection of non-hazardous waste	Casglu gwastraff nad yw'n beryglus		
+38.12	38.1	Collection of hazardous waste	Casglu gwastraff peryglus		
+38.2	38	Waste treatment and disposal			
+38.21	38.2	Treatment and disposal of non-hazardous waste	Trin a gwaredu gwastraff nad yw'n beryglus		
+38.22	38.2	Treatment and disposal of hazardous waste	Trin a gwaredu gwastraff peryglus		
+38.3	38	Materials recovery			
+38.31	38.3	Dismantling of wrecks	Datgymalu drylliadau		
+38.32	38.3	Recovery of sorted materials	Adfer deunyddiau a ddidolwyd		
 39	E	Remediation activities and other waste management services.			
-390	39	Remediation activities and other waste management services			
-39000	390	Remediation activities and other waste management services	Gweithgareddau adfer a gwasanaethau rheoli gwastraff eraill		
+39.0	39	Remediation activities and other waste management services			
+39.00	39.0	Remediation activities and other waste management services	Gweithgareddau adfer a gwasanaethau rheoli gwastraff eraill		
 41	F	Construction of buildings			
-411	41	Development of building projects			
-41100	411	Development of building projects	Datblygu projectau adeiladu		
-412	41	Construction of residential and non-residential buildings			
-41200	412	Construction of residential and non-residential buildings			
-41201	41200	Construction of commercial buildings	Adeiladu adeiladau masnachol		
-41202	41200	Construction of domestic buildings	Adeiladu adeiladau domestig		
+41.1	41	Development of building projects			
+41.10	41.1	Development of building projects	Datblygu projectau adeiladu		
+41.2	41	Construction of residential and non-residential buildings			
+41.20	41.2	Construction of residential and non-residential buildings			
+41.20/1	41.20	Construction of commercial buildings	Adeiladu adeiladau masnachol		
+41.20/2	41.20	Construction of domestic buildings	Adeiladu adeiladau domestig		
 42	F	Civil engineering			
-421	42	Construction of roads and railways			
-42110	421	Construction of roads and motorways	Adeiladu ffyrdd a phriffyrdd		
-42120	421	Construction of railways and underground railways	Adeiladu rheilffyrdd a rheilffyrdd tanddaearol		
-42130	421	Construction of bridges and tunnels	Adeiladu pontydd a thwneli		
-422	42	Construction of utility projects			
-42210	422	Construction of utility projects for fluids	Adeiladu projectau cyfleustodau hylifau		
-42220	422	Construction of utility projects for electricity and telecommunications	Adeiladu projectau cyfleustodau trydan a thelathrebu		
-429	42	Construction of other civil engineering projects			
-42910	429	Construction of water projects	Adeiladu projectau dŵr		
-42990	429	Construction of other civil engineering projects not elsewhere classified	Adeiladu projectau peirianneg sifil eraill n.dd.b.		
+42.1	42	Construction of roads and railways			
+42.11	42.1	Construction of roads and motorways	Adeiladu ffyrdd a phriffyrdd		
+42.12	42.1	Construction of railways and underground railways	Adeiladu rheilffyrdd a rheilffyrdd tanddaearol		
+42.13	42.1	Construction of bridges and tunnels	Adeiladu pontydd a thwneli		
+42.2	42	Construction of utility projects			
+42.21	42.2	Construction of utility projects for fluids	Adeiladu projectau cyfleustodau hylifau		
+42.22	42.2	Construction of utility projects for electricity and telecommunications	Adeiladu projectau cyfleustodau trydan a thelathrebu		
+42.9	42	Construction of other civil engineering projects			
+42.91	42.9	Construction of water projects	Adeiladu projectau dŵr		
+42.99	42.9	Construction of other civil engineering projects not elsewhere classified	Adeiladu projectau peirianneg sifil eraill n.dd.b.		
 43	F	Specialised construction activities			
-431	43	Demolition and site preparation			
-43110	431	Demolition	Dymchwel		
-43120	431	Site preparation	Paratoi safleoedd		
-43130	431	Test drilling and boring	Drilio a thorri tyllau profi		
-432	43	Electrical, plumbing and other construction installation activities			
-43210	432	Electrical installation	Gosod offer trydanol		
-43220	432	Plumbing, heat and air-conditioning installation	Gosod systemau plymio, gwres a thymheru'r aer		
-43290	432	Other construction installation	Mathau eraill osod at ddibenion adeiladu		
-433	43	Building completion and finishing			
-43310	433	Plastering	Plastro		
-43320	433	Joinery installation	Gosod gwaith coed		
-43330	433	Floor and wall covering	Gorchuddio lloriau a waliau		
-43340	433	Painting and glazing			
-43341	43340	Painting	Peintio		
-43342	43340	Glazing	Gwydro		
-43390	433	Other building completion and finishing	Gwaith gorffen a gorffennu adeiladu eraill		
-439	43	Other specialised construction activities			
-43910	439	Roofing activities	Gweithgareddau gosod to		
-43990	439	Other specialised construction activities not elsewhere classified			
-43991	43990	Scaffold erection	Codi sgaffaldiau		
-43999	43990	Other specialised construction activities not elsewhere classified	Gweithgareddau adeiladu arbenigol eraill n.dd.b.		
+43.1	43	Demolition and site preparation			
+43.11	43.1	Demolition	Dymchwel		
+43.12	43.1	Site preparation	Paratoi safleoedd		
+43.13	43.1	Test drilling and boring	Drilio a thorri tyllau profi		
+43.2	43	Electrical, plumbing and other construction installation activities			
+43.21	43.2	Electrical installation	Gosod offer trydanol		
+43.22	43.2	Plumbing, heat and air-conditioning installation	Gosod systemau plymio, gwres a thymheru'r aer		
+43.29	43.2	Other construction installation	Mathau eraill osod at ddibenion adeiladu		
+43.3	43	Building completion and finishing			
+43.31	43.3	Plastering	Plastro		
+43.32	43.3	Joinery installation	Gosod gwaith coed		
+43.33	43.3	Floor and wall covering	Gorchuddio lloriau a waliau		
+43.34	43.3	Painting and glazing			
+43.34/1	43.34	Painting	Peintio		
+43.34/2	43.34	Glazing	Gwydro		
+43.39	43.3	Other building completion and finishing	Gwaith gorffen a gorffennu adeiladu eraill		
+43.9	43	Other specialised construction activities			
+43.91	43.9	Roofing activities	Gweithgareddau gosod to		
+43.99	43.9	Other specialised construction activities not elsewhere classified			
+43.99/1	43.99	Scaffold erection	Codi sgaffaldiau		
+43.99/9	43.99	Other specialised construction activities not elsewhere classified	Gweithgareddau adeiladu arbenigol eraill n.dd.b.		
 45	G	Wholesale and retail trade and repair of motor vehicles and motorcycles			
-451	45	Sale of motor vehicles			
-45110	451	Sale of cars and light motor vehicles			
-45111	45110	Sale of new cars and light motor vehicles	Gwerthu ceir a cherbydau modur ysgafn newydd		
-45112	45110	Sale of used cars and light motor vehicles	Gwerthu ceir a cherbydau modur ysgafn ail law		
-45190	451	Sale of other motor vehicles	Gwerthu cerbydau modur eraill		
-452	45	Maintenance and repair of motor vehicles			
-45200	452	Maintenance and repair of motor vehicles	Cynnal ac atgyweirio cerbydau modur		
-453	45	Sale of motor vehicle parts and accessories			
-45310	453	Wholesale trade of motor vehicle parts and accessories	Cyfanwerthu darnau ac ategolion cerbydau modur		
-45320	453	Retail trade of motor vehicle parts and accessories	Adwerthu darnau ac ategolion cerbydau modur		
-454	45	Sale, maintenance and repair of motorcycles and related parts and accessories			
-45400	454	Sale, maintenance and repair of motorcycles and related parts and accessories	Gwerthu, cynnal ac atgyweirio beiciau modur a darnau ac ategolion cysylltiedig		
+45.1	45	Sale of motor vehicles			
+45.11	45.1	Sale of cars and light motor vehicles			
+45.11/1	45.11	Sale of new cars and light motor vehicles	Gwerthu ceir a cherbydau modur ysgafn newydd		
+45.11/2	45.11	Sale of used cars and light motor vehicles	Gwerthu ceir a cherbydau modur ysgafn ail law		
+45.19	45.1	Sale of other motor vehicles	Gwerthu cerbydau modur eraill		
+45.2	45	Maintenance and repair of motor vehicles			
+45.20	45.2	Maintenance and repair of motor vehicles	Cynnal ac atgyweirio cerbydau modur		
+45.3	45	Sale of motor vehicle parts and accessories			
+45.31	45.3	Wholesale trade of motor vehicle parts and accessories	Cyfanwerthu darnau ac ategolion cerbydau modur		
+45.32	45.3	Retail trade of motor vehicle parts and accessories	Adwerthu darnau ac ategolion cerbydau modur		
+45.4	45	Sale, maintenance and repair of motorcycles and related parts and accessories			
+45.40	45.4	Sale, maintenance and repair of motorcycles and related parts and accessories	Gwerthu, cynnal ac atgyweirio beiciau modur a darnau ac ategolion cysylltiedig		
 46	G	Wholesale trade, except of motor vehicles and motorcycles			
-461	46	Wholesale on a fee or contract basis			
-46110	461	Agents selling agricultural raw materials, livestock, textile raw materials and semi-finished goods	Asiantau sy'n gwerthu deunydd crai amaethyddol, da byw, deunyddiau crai tecstilau a nwyddau lled-barod		
-46120	461	Agents involved in the sale of fuels, ores, metals and industrial chemicals	Asiantau sydd ynghlwm wrth werthu tanwydd, mwynau, metelau a chemegion diwydiannol		
-46130	461	Agents involved in the sale of timber and building materials	Asiantau sydd ynghlwm wrth werthu pren a deunyddiau adeiladu		
-46140	461	Agents involved in the sale of machinery, industrial equipment, ships and aircraft	Asiantau sydd ynghlwm wrth werthu peiriannau, offer diwydiannol, llongau ac awyrennau		
-46150	461	Agents involved in the sale of furniture, household goods, hardware and ironmongery	Asiantau sydd ynghlwm wrth werthu celfi, nwyddau cartref, caledwedd a nwyddau haearn		
-46160	461	Agents involved in the sale of textiles, clothing, fur, footwear and leather goods	Asiantau sydd ynghlwm wrth werthu tecstilau, dillad, ffwr, esgidiau a nwyddau lledr		
-46170	461	Agents involved in the sale of food, beverages and tobacco	Asiantau sydd ynghlwm wrth werthu bwydydd, diodydd a thybaco		
-46180	461	Agents specialised in the sale of other particular products	Asiantau sy'n arbenigo mewn gwerthu cynhyrchion penodol eraill		
-46190	461	Agents involved in the sale of a variety of goods	Asiantau sydd ynghlwm wrth werthu amrywiaeth o nwyddau		
-462	46	Wholesale of agricultural raw materials and live animals			
-46210	462	Wholesale of grain, unmanufactured tobacco, seeds and animal feeds	Cyfanwerthu grawn, tybaco crai, hadau a bwydydd anifeiliaid		
-46220	462	Wholesale of flowers and plants	Cyfanwerthu blodau a phlanhigion		
-46230	462	Wholesale of live animals	Cyfanwerthu anifeiliaid byw		
-46240	462	Wholesale of hides, skins and leather	Cyfanwerthu crwyn a lledr		
-463	46	Wholesale of food, beverages and tobacco			
-46310	463	Wholesale of fruit and vegetables	Cyfanwerthu ffrwythau a llysiau		
-46320	463	Wholesale of meat and meat products	Cyfanwerthu cig a chynhyrchion cig		
-46330	463	Wholesale of dairy products, eggs and edible oils and fats	Cyfanwerthu cynhyrchion llaeth, wyau ac olewon a brasterau bwytadwy		
-46340	463	Wholesale of beverages			
-46341	46340	Wholesale of fruit and vegetable juices, mineral water and soft drinks	Cyfanwerthu sudd ffrwythau a llysiau, dŵr mwynol a diodydd ysgafn		
-46342	46340	Wholesale of wine, beer, spirits and other alcoholic beverages	Cyfanwerthu gwin, cwrw, gwirodydd a diodydd meddwol eraill		
-46350	463	Wholesale of tobacco products	Cyfanwerthu cynhyrchion tybaco		
-46360	463	Wholesale of sugar and chocolate and sugar confectionery	Cyfanwerthu siwgr a siocled a melysion siwgr		
-46370	463	Wholesale of coffee, tea, cocoa and spices	Cyfanwerthu coffi, te, coco a sbeis		
-46380	463	Wholesale of other food, including fish, crustaceans and molluscs	Cyfanwerthu bwydydd eraill, gan gynnwys pysgod, cramenogion a molysgiaid		
-46390	463	Non-specialised wholesale of food, beverages and tobacco	Cyfanwerthu bwydydd, diodydd a thybaco cyffredinol		
-464	46	Wholesale of household goods			
-46410	464	Wholesale of textiles	Cyfanwerthu tecstilau		
-46420	464	Wholesale of clothing and footwear	Cyfanwerthu dillad ac esgidiau		
-46430	464	Wholesale of electrical household appliances			
-46431	46430	Wholesale of audio tapes, records, CDs and video tapes and the equipment on which these are played	Cyfanwerthu tapiau sain, recordiau, CDs a thapiau fideo a'r offer ar gyfer eu chwarae		
-46439	46430	Wholesale of radio, television goods & electrical household appliances (other than records, tapes, CD's & video tapes and the equipment used for playing them)	Cyfanwerthu nwyddau radio a theledu a dyfeisiau trydan i’r cartref (ac eithrio recordiau, tapiau, CDs a thapiau fideo, a’r offer a ddefnyddir i’w chwarae)		
-46440	464	Wholesale of china and glassware and cleaning materials	Cyfanwerthu llestri gwydr a tsieina a deunyddiau glanhau		
-46450	464	Wholesale of perfume and cosmetics	Cyfanwerthu persawr a chosmetigau		
-46460	464	Wholesale of pharmaceutical goods	Cyfanwerthu nwyddau fferyllol		
-46470	464	Wholesale of furniture, carpets and lighting equipment	Cyfanwerthu celfi, carpedi ac offer goleuo		
-46480	464	Wholesale of watches and jewellery	Cyfanwerthu watsys a gemwaith		
-46490	464	Wholesale of other household goods			
-46491	46490	Wholesale of musical instruments	Cyfanwerthu offerynnau cerdd		
-46499	46490	Wholesale of household goods (other than musical instruments) n.e.c	Cyfanwerthu nwyddau cartref (ac eithrio offerynnau cerdd) n.dd.b.		
-465	46	Wholesale of information and communication equipment			
-46510	465	Wholesale of computers, computer peripheral equipment and software	Cyfanwerthu cyfrifiaduron, perifferolion cyfrifiadurol a meddalwedd		
-46520	465	Wholesale of electronic and telecommunications equipment and parts	Cyfanwerthu cyfarpar electronig a thelathrebu a'r darnau cysylltiedig		
-466	46	Wholesale of other machinery, equipment and supplies			
-46610	466	Wholesale of agricultural machinery, equipment and supplies	Cyfanwerthu peiriannau, cyfarpar a chyflenwadau amaethyddol		
-46620	466	Wholesale of machine tools	Cyfanwerthu offer peiriannol		
-46630	466	Wholesale of mining, construction and civil engineering machinery	Cyfanwerthu peiriannau mwyngloddio, adeiladu a pheirianneg sifil		
-46640	466	Wholesale of machinery for the textile industry and of sewing and knitting machines	Cyfanwerthu peiriannau ar gyfer y diwydiant tecstilau a pheiriannau gwnïo a gwau		
-46650	466	Wholesale of office furniture	Cyfanwerthu celfi swyddfa		
-46660	466	Wholesale of other office machinery and equipment	Cyfanwerthu peiriannau a chyfarpar swyddfa eraill		
-46690	466	Wholesale of other machinery and equipment	Cyfanwerthu peiriannau a chyfarpar eraill		
-467	46	Other specialised wholesale			
-46710	467	Wholesale of solid, liquid and gaseous fuels and related products			
-46711	46710	Wholesale of petroleum and petroleum products	Cyfanwerthu petrolewm a chynhyrchion petrolewm		
-46719	46710	Wholesale of other fuels and related products	Cyfanwerthu mathau eraill o danwydd a chynhyrchion cysylltiedig		
-46720	467	Wholesale of metals and metal ores	Cyfanwerthu metelau a mwynau metel		
-46730	467	Wholesale of wood, construction materials and sanitary equipment	Cyfanwerthu pren, deunyddiau adeiladu ac offer iechydol		
-46740	467	Wholesale of hardware, plumbing and heating equipment and supplies	Cyfanwerthu cyfarpar a nwyddau metel, plymio a gwresogi		
-46750	467	Wholesale of chemical products	Cyfanwerthu cynhyrchion cemegol		
-46760	467	Wholesale of other intermediate products	Cyfanwerthu cynhyrchion rhyngol eraill		
-46770	467	Wholesale of waste and scrap	Cyfanwerthu gwastraff a sgrap		
-469	46	Non-specialised wholesale trade			
-46900	469	Non-specialised wholesale trade	Masnach cyfanwerthu cyffredinol		
+46.1	46	Wholesale on a fee or contract basis			
+46.11	46.1	Agents selling agricultural raw materials, livestock, textile raw materials and semi-finished goods	Asiantau sy'n gwerthu deunydd crai amaethyddol, da byw, deunyddiau crai tecstilau a nwyddau lled-barod		
+46.12	46.1	Agents involved in the sale of fuels, ores, metals and industrial chemicals	Asiantau sydd ynghlwm wrth werthu tanwydd, mwynau, metelau a chemegion diwydiannol		
+46.13	46.1	Agents involved in the sale of timber and building materials	Asiantau sydd ynghlwm wrth werthu pren a deunyddiau adeiladu		
+46.14	46.1	Agents involved in the sale of machinery, industrial equipment, ships and aircraft	Asiantau sydd ynghlwm wrth werthu peiriannau, offer diwydiannol, llongau ac awyrennau		
+46.15	46.1	Agents involved in the sale of furniture, household goods, hardware and ironmongery	Asiantau sydd ynghlwm wrth werthu celfi, nwyddau cartref, caledwedd a nwyddau haearn		
+46.16	46.1	Agents involved in the sale of textiles, clothing, fur, footwear and leather goods	Asiantau sydd ynghlwm wrth werthu tecstilau, dillad, ffwr, esgidiau a nwyddau lledr		
+46.17	46.1	Agents involved in the sale of food, beverages and tobacco	Asiantau sydd ynghlwm wrth werthu bwydydd, diodydd a thybaco		
+46.18	46.1	Agents specialised in the sale of other particular products	Asiantau sy'n arbenigo mewn gwerthu cynhyrchion penodol eraill		
+46.19	46.1	Agents involved in the sale of a variety of goods	Asiantau sydd ynghlwm wrth werthu amrywiaeth o nwyddau		
+46.2	46	Wholesale of agricultural raw materials and live animals			
+46.21	46.2	Wholesale of grain, unmanufactured tobacco, seeds and animal feeds	Cyfanwerthu grawn, tybaco crai, hadau a bwydydd anifeiliaid		
+46.22	46.2	Wholesale of flowers and plants	Cyfanwerthu blodau a phlanhigion		
+46.23	46.2	Wholesale of live animals	Cyfanwerthu anifeiliaid byw		
+46.24	46.2	Wholesale of hides, skins and leather	Cyfanwerthu crwyn a lledr		
+46.3	46	Wholesale of food, beverages and tobacco			
+46.31	46.3	Wholesale of fruit and vegetables	Cyfanwerthu ffrwythau a llysiau		
+46.32	46.3	Wholesale of meat and meat products	Cyfanwerthu cig a chynhyrchion cig		
+46.33	46.3	Wholesale of dairy products, eggs and edible oils and fats	Cyfanwerthu cynhyrchion llaeth, wyau ac olewon a brasterau bwytadwy		
+46.34	46.3	Wholesale of beverages			
+46.34/1	46.34	Wholesale of fruit and vegetable juices, mineral water and soft drinks	Cyfanwerthu sudd ffrwythau a llysiau, dŵr mwynol a diodydd ysgafn		
+46.34/2	46.34	Wholesale of wine, beer, spirits and other alcoholic beverages	Cyfanwerthu gwin, cwrw, gwirodydd a diodydd meddwol eraill		
+46.35	46.3	Wholesale of tobacco products	Cyfanwerthu cynhyrchion tybaco		
+46.36	46.3	Wholesale of sugar and chocolate and sugar confectionery	Cyfanwerthu siwgr a siocled a melysion siwgr		
+46.37	46.3	Wholesale of coffee, tea, cocoa and spices	Cyfanwerthu coffi, te, coco a sbeis		
+46.38	46.3	Wholesale of other food, including fish, crustaceans and molluscs	Cyfanwerthu bwydydd eraill, gan gynnwys pysgod, cramenogion a molysgiaid		
+46.39	46.3	Non-specialised wholesale of food, beverages and tobacco	Cyfanwerthu bwydydd, diodydd a thybaco cyffredinol		
+46.4	46	Wholesale of household goods			
+46.41	46.4	Wholesale of textiles	Cyfanwerthu tecstilau		
+46.42	46.4	Wholesale of clothing and footwear	Cyfanwerthu dillad ac esgidiau		
+46.43	46.4	Wholesale of electrical household appliances			
+46.43/1	46.43	Wholesale of audio tapes, records, CDs and video tapes and the equipment on which these are played	Cyfanwerthu tapiau sain, recordiau, CDs a thapiau fideo a'r offer ar gyfer eu chwarae		
+46.43/9	46.43	Wholesale of radio, television goods & electrical household appliances (other than records, tapes, CD's & video tapes and the equipment used for playing them)	Cyfanwerthu nwyddau radio a theledu a dyfeisiau trydan i’r cartref (ac eithrio recordiau, tapiau, CDs a thapiau fideo, a’r offer a ddefnyddir i’w chwarae)		
+46.44	46.4	Wholesale of china and glassware and cleaning materials	Cyfanwerthu llestri gwydr a tsieina a deunyddiau glanhau		
+46.45	46.4	Wholesale of perfume and cosmetics	Cyfanwerthu persawr a chosmetigau		
+46.46	46.4	Wholesale of pharmaceutical goods	Cyfanwerthu nwyddau fferyllol		
+46.47	46.4	Wholesale of furniture, carpets and lighting equipment	Cyfanwerthu celfi, carpedi ac offer goleuo		
+46.48	46.4	Wholesale of watches and jewellery	Cyfanwerthu watsys a gemwaith		
+46.49	46.4	Wholesale of other household goods			
+46.49/1	46.49	Wholesale of musical instruments	Cyfanwerthu offerynnau cerdd		
+46.49/9	46.49	Wholesale of household goods (other than musical instruments) n.e.c	Cyfanwerthu nwyddau cartref (ac eithrio offerynnau cerdd) n.dd.b.		
+46.5	46	Wholesale of information and communication equipment			
+46.51	46.5	Wholesale of computers, computer peripheral equipment and software	Cyfanwerthu cyfrifiaduron, perifferolion cyfrifiadurol a meddalwedd		
+46.52	46.5	Wholesale of electronic and telecommunications equipment and parts	Cyfanwerthu cyfarpar electronig a thelathrebu a'r darnau cysylltiedig		
+46.6	46	Wholesale of other machinery, equipment and supplies			
+46.61	46.6	Wholesale of agricultural machinery, equipment and supplies	Cyfanwerthu peiriannau, cyfarpar a chyflenwadau amaethyddol		
+46.62	46.6	Wholesale of machine tools	Cyfanwerthu offer peiriannol		
+46.63	46.6	Wholesale of mining, construction and civil engineering machinery	Cyfanwerthu peiriannau mwyngloddio, adeiladu a pheirianneg sifil		
+46.64	46.6	Wholesale of machinery for the textile industry and of sewing and knitting machines	Cyfanwerthu peiriannau ar gyfer y diwydiant tecstilau a pheiriannau gwnïo a gwau		
+46.65	46.6	Wholesale of office furniture	Cyfanwerthu celfi swyddfa		
+46.66	46.6	Wholesale of other office machinery and equipment	Cyfanwerthu peiriannau a chyfarpar swyddfa eraill		
+46.69	46.6	Wholesale of other machinery and equipment	Cyfanwerthu peiriannau a chyfarpar eraill		
+46.7	46	Other specialised wholesale			
+46.71	46.7	Wholesale of solid, liquid and gaseous fuels and related products			
+46.71/1	46.71	Wholesale of petroleum and petroleum products	Cyfanwerthu petrolewm a chynhyrchion petrolewm		
+46.71/9	46.71	Wholesale of other fuels and related products	Cyfanwerthu mathau eraill o danwydd a chynhyrchion cysylltiedig		
+46.72	46.7	Wholesale of metals and metal ores	Cyfanwerthu metelau a mwynau metel		
+46.73	46.7	Wholesale of wood, construction materials and sanitary equipment	Cyfanwerthu pren, deunyddiau adeiladu ac offer iechydol		
+46.74	46.7	Wholesale of hardware, plumbing and heating equipment and supplies	Cyfanwerthu cyfarpar a nwyddau metel, plymio a gwresogi		
+46.75	46.7	Wholesale of chemical products	Cyfanwerthu cynhyrchion cemegol		
+46.76	46.7	Wholesale of other intermediate products	Cyfanwerthu cynhyrchion rhyngol eraill		
+46.77	46.7	Wholesale of waste and scrap	Cyfanwerthu gwastraff a sgrap		
+46.9	46	Non-specialised wholesale trade			
+46.90	46.9	Non-specialised wholesale trade	Masnach cyfanwerthu cyffredinol		
 47	G	Retail trade, except of motor vehicles and motorcycles			
-471	47	Retail sale in non-specialised stores			
-47110	471	Retail sale in non-specialised stores with food, beverages or tobacco predominating	Adwerthu mewn siopau cyffredinol sy'n gwerthu bwydydd, diodydd a thybaco yn bennaf		
-47190	471	Other retail sale in non-specialised stores	Adwerthu arall mewn siopau cyffredinol		
-472	47	Retail sale of food, beverages and tobacco in specialised stores			
-47210	472	Retail sale of fruit and vegetables in specialised stores	Adwerthu ffrwythau a llysiau mewn siopau arbenigol		
-47220	472	Retail sale of meat and meat products in specialised stores	Adwerthu cig a chynhyrchion cig mewn siopau arbenigol		
-47230	472	Retail sale of fish, crustaceans and molluscs in specialised stores	Adwerthu pysgod, cramenogion a molysgiaid mewn siopau arbenigol		
-47240	472	Retail sale of bread, cakes, flour confectionery and sugar confectionery in specialised stores	Adwerthu bara, cacennau, melysion cannog a melysion siwgr mewn siopau arbenigol		
-47250	472	Retail sale of beverages in specialised stores	Adwerthu diodydd mewn siopau arbenigol		
-47260	472	Retail sale of tobacco products in specialised stores	Adwerthu cynhyrchion tybaco mewn siopau arbenigol		
-47290	472	Other retail sale of food in specialised stores	Adwerthu bwydydd eraill mewn siopau arbenigol		
-473	47	Retail sale of automotive fuel in specialised stores			
-47300	473	Retail sale of automotive fuel in specialised stores	Adwerthu tanwydd cerbydau modur mewn siopau arbenigol		
-474	47	Retail sale of information and communication equipment in specialised stores			
-47410	474	Retail sale of computers, peripheral units and software in specialised stores	Adwerthu cyfrifiaduron, unedau perifferol a meddalwedd mewn siopau arbenigol		
-47420	474	Retail sale of telecommunications equipment in specialised stores			
-47421	47420	Retail sale of mobile telephones	Adwerthu teleffonau symudol		
-47429	47420	Retail sale of telecommunications equipment other than mobile telephones	Adwerthu offer telathrebu ac eithrio teleffonau symudol		
-47430	474	Retail sale of audio and video equipment in specialised stores	Adwerthu offer sain a fideo mewn siopau arbenigol		
-475	47	Retail sale of other household equipment in specialised stores			
-47510	475	Retail sale of textiles in specialised stores	Adwerthu tecstilau mewn siopau arbenigol		
-47520	475	Retail sale of hardware, paints and glass in specialised stores	Adwerthu nwyddau haearn, paent a gwydr mewn siopau arbenigol		
-47530	475	Retail sale of carpets, rugs, wall and floor coverings in specialised stores	Adwerthu carpedi, rygiau, a gorchuddion waliau a lloriau mewn siopau arbenigol		
-47540	475	Retail sale of electrical household appliances in specialised stores	Adwerthu dyfeisiau cartref trydanol mewn siopau arbenigol		
-47590	475	Retail sale of furniture, lighting equipment and other household articles in specialised stores			
-47591	47590	Retail sale of musical instruments and scores	Adwerthu offerynnau cerdd a sgoriau		
-47599	47590	Retail of furniture, lighting, and similar (not musical instruments or scores) in specialised store	Adwerthu celfi, goleuadau a phethau tebyg (nid offerynnau cerdd na sgoriau) mewn siopau arbenigol		
-476	47	Retail sale of cultural and recreation goods in specialised stores			
-47610	476	Retail sale of books in specialised stores	Adwerthu llyfrau mewn siopau arbenigol		
-47620	476	Retail sale of newspapers and stationery in specialised stores	Adwerthu papurau newydd a deunyddiau ysgrifennu mewn siopau arbenigol		
-47630	476	Retail sale of music and video recordings in specialised stores	Adwerthu recordiadau cerddorol a fideo mewn siopau arbenigol		
-47640	476	Retail sale of sports goods, fishing gear, camping goods, boats and bicycles	Adwerthu nwyddau chwaraeon, offer pysgota, offer gwersylla, cychod a beiciau		
-47650	476	Retail sale of games and toys in specialised stores	Adwerthu gemau a theganau mewn siopau arbenigol		
-477	47	Retail sale of other goods in specialised stores			
-47710	477	Retail sale of clothing in specialised stores	Adwerthu dillad mewn siopau arbenigol		
-47720	477	Retail sale of footwear and leather goods in specialised stores			
-47721	47720	Retail sale of footwear in specialised stores	Adwerthu esgidiau mewn siopau arbenigol		
-47722	47720	Retail sale of leather goods in specialised stores	Adwerthu nwyddau lledr mewn siopau arbenigol		
-47730	477	Dispensing chemist in specialised stores	Fferyllwyr cymwysedig mewn siop arbenigol		
-47740	477	Retail sale of medical and orthopaedic goods in specialised stores			
-47741	47740	Retail sale of hearing aids	Adwerthu cymhorthion clyw		
-47749	47740	Retail sale of medical and orthopaedic goods in specialised stores (not incl. hearing aids) not elsewhere classified	Adwerthu nwyddau meddygol ac orthopaedig  mewn siopau arbenigol (ac eithrio cymhorthion clyw) n.dd.b.		
-47750	477	Retail sale of cosmetic and toilet articles in specialised stores	Adwerthu nwyddau cosmetig ac ymolchi mewn siopau arbenigol		
-47760	477	Retail sale of flowers, plants, seeds, fertilizers, pet animals and pet food in specialised stores	Adwerthu blodau, planhigion, hadau, gwrtaith, anifeiliaid anwes a bwyd anifeiliaid anwes mewn siopau arbenigol		
-47770	477	Retail sale of watches and jewellery in specialised stores	Adwerthu watsys a gemwaith mewn siopau arbenigol		
-47780	477	Other retail sale of new goods in specialised stores			
-47781	47780	Retail sale in commercial art galleries	Adwerthu mewn orielau celf masnachol		
-47782	47780	Retail sale by opticians	Adwerthu gan optegwyr		
-47789	47780	Other retail sale of new goods in specialised stores (not commercial art galleries and opticians)	Adwerthu nwyddau newydd eraill mewn siopau arbenigol (nid orielau celf masnachol nac optegwyr)		
-47790	477	Retail sale of second-hand goods in stores			
-47791	47790	Retail sale of antiques including antique books in stores	Adwerthu hen greiriau gan gynnwys hen lyfrau mewn siopau		
-47799	47790	Retail sale of other second-hand goods in stores (not incl. antiques)	Adwerthu nwyddau ail-law eraill mewn siopau (ac eithrio hen greiriau)		
-478	47	Retail sale via stalls and markets			
-47810	478	Retail sale via stalls and markets of food, beverages and tobacco products	Adwerthu bwydydd, diodydd a chynhyrchion tybaco o stondinau a thrwy farchnadoedd		
-47820	478	Retail sale via stalls and markets of textiles, clothing and footwear	Adwerthu tecstilau, dillad ac esgidiau o stondinau a thrwy farchnadoedd		
-47890	478	Retail sale via stalls and markets of other goods	Adwerthu nwyddau eraill o stondinau a thrwy farchnadoedd		
-479	47	Retail trade not in stores, stalls or markets			
-47910	479	Retail sale via mail order houses or via Internet	Adwerthu trwy'r post neu dros y Rhyngrwyd		
-47990	479	Other retail sale not in stores, stalls or markets	Adwerthu arall heb fod mewn siopau, o stondinau neu drwy farchnadoedd		
+47.1	47	Retail sale in non-specialised stores			
+47.11	47.1	Retail sale in non-specialised stores with food, beverages or tobacco predominating	Adwerthu mewn siopau cyffredinol sy'n gwerthu bwydydd, diodydd a thybaco yn bennaf		
+47.19	47.1	Other retail sale in non-specialised stores	Adwerthu arall mewn siopau cyffredinol		
+47.2	47	Retail sale of food, beverages and tobacco in specialised stores			
+47.21	47.2	Retail sale of fruit and vegetables in specialised stores	Adwerthu ffrwythau a llysiau mewn siopau arbenigol		
+47.22	47.2	Retail sale of meat and meat products in specialised stores	Adwerthu cig a chynhyrchion cig mewn siopau arbenigol		
+47.23	47.2	Retail sale of fish, crustaceans and molluscs in specialised stores	Adwerthu pysgod, cramenogion a molysgiaid mewn siopau arbenigol		
+47.24	47.2	Retail sale of bread, cakes, flour confectionery and sugar confectionery in specialised stores	Adwerthu bara, cacennau, melysion cannog a melysion siwgr mewn siopau arbenigol		
+47.25	47.2	Retail sale of beverages in specialised stores	Adwerthu diodydd mewn siopau arbenigol		
+47.26	47.2	Retail sale of tobacco products in specialised stores	Adwerthu cynhyrchion tybaco mewn siopau arbenigol		
+47.29	47.2	Other retail sale of food in specialised stores	Adwerthu bwydydd eraill mewn siopau arbenigol		
+47.3	47	Retail sale of automotive fuel in specialised stores			
+47.30	47.3	Retail sale of automotive fuel in specialised stores	Adwerthu tanwydd cerbydau modur mewn siopau arbenigol		
+47.4	47	Retail sale of information and communication equipment in specialised stores			
+47.41	47.4	Retail sale of computers, peripheral units and software in specialised stores	Adwerthu cyfrifiaduron, unedau perifferol a meddalwedd mewn siopau arbenigol		
+47.42	47.4	Retail sale of telecommunications equipment in specialised stores			
+47.42/1	47.42	Retail sale of mobile telephones	Adwerthu teleffonau symudol		
+47.42/9	47.42	Retail sale of telecommunications equipment other than mobile telephones	Adwerthu offer telathrebu ac eithrio teleffonau symudol		
+47.43	47.4	Retail sale of audio and video equipment in specialised stores	Adwerthu offer sain a fideo mewn siopau arbenigol		
+47.5	47	Retail sale of other household equipment in specialised stores			
+47.51	47.5	Retail sale of textiles in specialised stores	Adwerthu tecstilau mewn siopau arbenigol		
+47.52	47.5	Retail sale of hardware, paints and glass in specialised stores	Adwerthu nwyddau haearn, paent a gwydr mewn siopau arbenigol		
+47.53	47.5	Retail sale of carpets, rugs, wall and floor coverings in specialised stores	Adwerthu carpedi, rygiau, a gorchuddion waliau a lloriau mewn siopau arbenigol		
+47.54	47.5	Retail sale of electrical household appliances in specialised stores	Adwerthu dyfeisiau cartref trydanol mewn siopau arbenigol		
+47.59	47.5	Retail sale of furniture, lighting equipment and other household articles in specialised stores			
+47.59/1	47.59	Retail sale of musical instruments and scores	Adwerthu offerynnau cerdd a sgoriau		
+47.59/9	47.59	Retail of furniture, lighting, and similar (not musical instruments or scores) in specialised store	Adwerthu celfi, goleuadau a phethau tebyg (nid offerynnau cerdd na sgoriau) mewn siopau arbenigol		
+47.6	47	Retail sale of cultural and recreation goods in specialised stores			
+47.61	47.6	Retail sale of books in specialised stores	Adwerthu llyfrau mewn siopau arbenigol		
+47.62	47.6	Retail sale of newspapers and stationery in specialised stores	Adwerthu papurau newydd a deunyddiau ysgrifennu mewn siopau arbenigol		
+47.63	47.6	Retail sale of music and video recordings in specialised stores	Adwerthu recordiadau cerddorol a fideo mewn siopau arbenigol		
+47.64	47.6	Retail sale of sports goods, fishing gear, camping goods, boats and bicycles	Adwerthu nwyddau chwaraeon, offer pysgota, offer gwersylla, cychod a beiciau		
+47.65	47.6	Retail sale of games and toys in specialised stores	Adwerthu gemau a theganau mewn siopau arbenigol		
+47.7	47	Retail sale of other goods in specialised stores			
+47.71	47.7	Retail sale of clothing in specialised stores	Adwerthu dillad mewn siopau arbenigol		
+47.72	47.7	Retail sale of footwear and leather goods in specialised stores			
+47.72/1	47.72	Retail sale of footwear in specialised stores	Adwerthu esgidiau mewn siopau arbenigol		
+47.72/2	47.72	Retail sale of leather goods in specialised stores	Adwerthu nwyddau lledr mewn siopau arbenigol		
+47.73	47.7	Dispensing chemist in specialised stores	Fferyllwyr cymwysedig mewn siop arbenigol		
+47.74	47.7	Retail sale of medical and orthopaedic goods in specialised stores			
+47.74/1	47.74	Retail sale of hearing aids	Adwerthu cymhorthion clyw		
+47.74/9	47.74	Retail sale of medical and orthopaedic goods in specialised stores (not incl. hearing aids) not elsewhere classified	Adwerthu nwyddau meddygol ac orthopaedig  mewn siopau arbenigol (ac eithrio cymhorthion clyw) n.dd.b.		
+47.75	47.7	Retail sale of cosmetic and toilet articles in specialised stores	Adwerthu nwyddau cosmetig ac ymolchi mewn siopau arbenigol		
+47.76	47.7	Retail sale of flowers, plants, seeds, fertilizers, pet animals and pet food in specialised stores	Adwerthu blodau, planhigion, hadau, gwrtaith, anifeiliaid anwes a bwyd anifeiliaid anwes mewn siopau arbenigol		
+47.77	47.7	Retail sale of watches and jewellery in specialised stores	Adwerthu watsys a gemwaith mewn siopau arbenigol		
+47.78	47.7	Other retail sale of new goods in specialised stores			
+47.78/1	47.78	Retail sale in commercial art galleries	Adwerthu mewn orielau celf masnachol		
+47.78/2	47.78	Retail sale by opticians	Adwerthu gan optegwyr		
+47.78/9	47.78	Other retail sale of new goods in specialised stores (not commercial art galleries and opticians)	Adwerthu nwyddau newydd eraill mewn siopau arbenigol (nid orielau celf masnachol nac optegwyr)		
+47.79	47.7	Retail sale of second-hand goods in stores			
+47.79/1	47.79	Retail sale of antiques including antique books in stores	Adwerthu hen greiriau gan gynnwys hen lyfrau mewn siopau		
+47.79/9	47.79	Retail sale of other second-hand goods in stores (not incl. antiques)	Adwerthu nwyddau ail-law eraill mewn siopau (ac eithrio hen greiriau)		
+47.8	47	Retail sale via stalls and markets			
+47.81	47.8	Retail sale via stalls and markets of food, beverages and tobacco products	Adwerthu bwydydd, diodydd a chynhyrchion tybaco o stondinau a thrwy farchnadoedd		
+47.82	47.8	Retail sale via stalls and markets of textiles, clothing and footwear	Adwerthu tecstilau, dillad ac esgidiau o stondinau a thrwy farchnadoedd		
+47.89	47.8	Retail sale via stalls and markets of other goods	Adwerthu nwyddau eraill o stondinau a thrwy farchnadoedd		
+47.9	47	Retail trade not in stores, stalls or markets			
+47.91	47.9	Retail sale via mail order houses or via Internet	Adwerthu trwy'r post neu dros y Rhyngrwyd		
+47.99	47.9	Other retail sale not in stores, stalls or markets	Adwerthu arall heb fod mewn siopau, o stondinau neu drwy farchnadoedd		
 49	H	Land transport and transport via pipelines			
-491	49	Passenger rail transport, interurban			
-49100	491	Passenger rail transport, interurban	Cludo teithwyr ar y rheilffordd, rhyngdrefol		
-492	49	Freight rail transport			
-49200	492	Freight rail transport	Cludo nwyddau ar y rheilffordd		
-493	49	Other passenger land transport			
-49310	493	Urban and suburban passenger land transport			
-49311	49310	Urban and suburban passenger railway transportation by underground, metro and similar systems	Cludo teithwyr trefol a maestrefol ar systemau rheilffyrdd tanddaearol, metro a systemau tebyg		
-49319	49310	Other urban, suburban or metropolitan passenger land transport (not underground, metro or similar)	Cludo teithwyr trefol, maestrefol neu ddinesig dros y tir (nid systemau tanddaearol, metro na'u tebyg)		
-49320	493	Taxi operation	Busnes tacsi		
-49390	493	Other passenger land transport	Dulliau eraill o gludo teithwyr ar y tir		
-494	49	Freight transport by road and removal services			
-49410	494	Freight transport by road	Cludo nwyddau ar y ffyrdd		
-49420	494	Removal services	Gwasanaethau mudo		
-495	49	Transport via pipeline			
-49500	495	Transport via pipeline	Trafnidiaeth trwy lein beipiau		
+49.1	49	Passenger rail transport, interurban			
+49.10	49.1	Passenger rail transport, interurban	Cludo teithwyr ar y rheilffordd, rhyngdrefol		
+49.2	49	Freight rail transport			
+49.20	49.2	Freight rail transport	Cludo nwyddau ar y rheilffordd		
+49.3	49	Other passenger land transport			
+49.31	49.3	Urban and suburban passenger land transport			
+49.31/1	49.31	Urban and suburban passenger railway transportation by underground, metro and similar systems	Cludo teithwyr trefol a maestrefol ar systemau rheilffyrdd tanddaearol, metro a systemau tebyg		
+49.31/9	49.31	Other urban, suburban or metropolitan passenger land transport (not underground, metro or similar)	Cludo teithwyr trefol, maestrefol neu ddinesig dros y tir (nid systemau tanddaearol, metro na'u tebyg)		
+49.32	49.3	Taxi operation	Busnes tacsi		
+49.39	49.3	Other passenger land transport	Dulliau eraill o gludo teithwyr ar y tir		
+49.4	49	Freight transport by road and removal services			
+49.41	49.4	Freight transport by road	Cludo nwyddau ar y ffyrdd		
+49.42	49.4	Removal services	Gwasanaethau mudo		
+49.5	49	Transport via pipeline			
+49.50	49.5	Transport via pipeline	Trafnidiaeth trwy lein beipiau		
 50	H	Water transport			
-501	50	Sea and coastal passenger water transport			
-50100	501	Sea and coastal passenger water transport	Cludo teithwyr ar ddyfroedd morol ac arfordirol		
-502	50	Sea and coastal freight water transport			
-50200	502	Sea and coastal freight water transport	Cludo nwyddau ar ddyfroedd morol ac arfordirol		
-503	50	Inland passenger water transport			
-50300	503	Inland passenger water transport	Cludo teithwyr ar ddyfroedd mewndirol		
-504	50	Inland freight water transport			
-50400	504	Inland freight water transport	Cludo nwyddau ar ddyfroedd mewndirol		
+50.1	50	Sea and coastal passenger water transport			
+50.10	50.1	Sea and coastal passenger water transport	Cludo teithwyr ar ddyfroedd morol ac arfordirol		
+50.2	50	Sea and coastal freight water transport			
+50.20	50.2	Sea and coastal freight water transport	Cludo nwyddau ar ddyfroedd morol ac arfordirol		
+50.3	50	Inland passenger water transport			
+50.30	50.3	Inland passenger water transport	Cludo teithwyr ar ddyfroedd mewndirol		
+50.4	50	Inland freight water transport			
+50.40	50.4	Inland freight water transport	Cludo nwyddau ar ddyfroedd mewndirol		
 51	H	Air transport			
-511	51	Passenger air transport			
-51100	511	Passenger air transport			
-51101	51100	Scheduled passenger air transport	Trafnidiaeth a raglennir ar gyfer teithwyr awyr		
-51102	51100	Non-scheduled passenger air transport	Trafnidiaeth na raglennir ar gyfer teithwyr awyr		
-512	51	Freight air transport and space transport			
-51210	512	Freight air transport	Trafnidiaeth awyr ar gyfer nwyddau		
-51220	512	Space transport	Trafnidiaeth y gofod		
+51.1	51	Passenger air transport			
+51.10	51.1	Passenger air transport			
+51.10/1	51.10	Scheduled passenger air transport	Trafnidiaeth a raglennir ar gyfer teithwyr awyr		
+51.10/2	51.10	Non-scheduled passenger air transport	Trafnidiaeth na raglennir ar gyfer teithwyr awyr		
+51.2	51	Freight air transport and space transport			
+51.21	51.2	Freight air transport	Trafnidiaeth awyr ar gyfer nwyddau		
+51.22	51.2	Space transport	Trafnidiaeth y gofod		
 52	H	Warehousing and support activities for transportation			
-521	52	Warehousing and storage			
-52100	521	Warehousing and storage			
-52101	52100	Operation of warehousing and storage facilities for water transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo ar y dŵr		
-52102	52100	Operation of warehousing and storage facilities for air transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo yn yr awyr		
-52103	52100	Operation of warehousing and storage facilities for land transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo ar y tir		
-522	52	Support activities for transportation			
-52210	522	Service activities incidental to land transportation			
-52211	52210	Operation of rail freight terminals	Gweithredu terfynellau cludo nwyddau ar y rheilffyrdd		
-52212	52210	Operation of rail passenger facilities at railway stations	Gweithredu cyfleusterau ar gyfer teithwyr mewn gorsafoedd rheilffordd		
-52213	52210	Operation of bus and coach passenger facilities at bus and coach stations	Gweithredu cyfleusterau ar gyfer teithwyr mewn gorsafoedd bysiau a choetsys		
-52219	52210	Other service activities incidental to land transportation, not elsewhere classified	Gwasanaethau eraill sydd ynghlwm wrth drafnidiaeth dros y tir, n.dd.b.		
-52220	522	Service activities incidental to water transportation	Gwasanaethau sydd ynghlwm wrth drafnidiaeth ar y dŵr		
-52230	522	Service activities incidental to air transportation	Gwasanaethau sydd ynghlwm wrth drafnidiaeth awyr		
-52240	522	Cargo handling			
-52241	52240	Cargo handling for water transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth ar y dŵr		
-52242	52240	Cargo handling for air transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth awyr		
-52243	52240	Cargo handling for land transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth dros y tir		
-52290	522	Other transportation support activities	Gweithgareddau eraill sy'n ategu trafnidiaeth		
+52.1	52	Warehousing and storage			
+52.10	52.1	Warehousing and storage			
+52.10/1	52.10	Operation of warehousing and storage facilities for water transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo ar y dŵr		
+52.10/2	52.10	Operation of warehousing and storage facilities for air transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo yn yr awyr		
+52.10/3	52.10	Operation of warehousing and storage facilities for land transport activities	Gweithredu stordai a chyfleusterau storio ar gyfer gweithgareddau cludo ar y tir		
+52.2	52	Support activities for transportation			
+52.21	52.2	Service activities incidental to land transportation			
+52.21/1	52.21	Operation of rail freight terminals	Gweithredu terfynellau cludo nwyddau ar y rheilffyrdd		
+52.21/2	52.21	Operation of rail passenger facilities at railway stations	Gweithredu cyfleusterau ar gyfer teithwyr mewn gorsafoedd rheilffordd		
+52.21/3	52.21	Operation of bus and coach passenger facilities at bus and coach stations	Gweithredu cyfleusterau ar gyfer teithwyr mewn gorsafoedd bysiau a choetsys		
+52.21/9	52.21	Other service activities incidental to land transportation, not elsewhere classified	Gwasanaethau eraill sydd ynghlwm wrth drafnidiaeth dros y tir, n.dd.b.		
+52.22	52.2	Service activities incidental to water transportation	Gwasanaethau sydd ynghlwm wrth drafnidiaeth ar y dŵr		
+52.23	52.2	Service activities incidental to air transportation	Gwasanaethau sydd ynghlwm wrth drafnidiaeth awyr		
+52.24	52.2	Cargo handling			
+52.24/1	52.24	Cargo handling for water transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth ar y dŵr		
+52.24/2	52.24	Cargo handling for air transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth awyr		
+52.24/3	52.24	Cargo handling for land transport activities	Dosbarthu cargo ar gyfer gweithgareddau trafnidiaeth dros y tir		
+52.29	52.2	Other transportation support activities	Gweithgareddau eraill sy'n ategu trafnidiaeth		
 53	H	Postal and courier activities			
-531	53	Postal activities under universal service obligation			
-53100	531	Postal activities under universal service obligation	Gweithgareddau post o dan rhwymedigaeth gwasanaeth gyffredinol		
-532	53	Other postal and courier activities			
-53200	532	Other postal and courier activities			
-53201	53200	Licensed carriers	Cludwr trwyddedig		
-53202	53200	Unlicensed carriers	Cludwr didrwydded		
+53.1	53	Postal activities under universal service obligation			
+53.10	53.1	Postal activities under universal service obligation	Gweithgareddau post o dan rhwymedigaeth gwasanaeth gyffredinol		
+53.2	53	Other postal and courier activities			
+53.20	53.2	Other postal and courier activities			
+53.20/1	53.20	Licensed carriers	Cludwr trwyddedig		
+53.20/2	53.20	Unlicensed carriers	Cludwr didrwydded		
 55	I	Accommodation			
-551	55	Hotels and similar accommodation			
-55100	551	Hotels and similar accommodation	Gwestai a llety tebyg		
-552	55	Holiday and other short-stay accommodation			
-55200	552	Holiday and other short-stay accommodation			
-55201	55200	Holiday centres and villages	Canolfannau a phentrefi gwyliau		
-55202	55200	Youth hostels	Hostelau ieuenctid		
-55209	55200	Other holiday and other collective accommodation	Llety gwyliau arall a mathau eraill o lety torfol		
-553	55	Camping grounds, recreational vehicle parks and trailer parks			
-55300	553	Recreational vehicle parks, trailer parks and camping grounds	Parciau cerbydau hamdden, parciau trelars a meysydd gwersylla		
-559	55	Other accommodation			
-55900	559	Other accommodation	Llety arall		
+55.1	55	Hotels and similar accommodation			
+55.10	55.1	Hotels and similar accommodation	Gwestai a llety tebyg		
+55.2	55	Holiday and other short-stay accommodation			
+55.20	55.2	Holiday and other short-stay accommodation			
+55.20/1	55.20	Holiday centres and villages	Canolfannau a phentrefi gwyliau		
+55.20/2	55.20	Youth hostels	Hostelau ieuenctid		
+55.20/9	55.20	Other holiday and other collective accommodation	Llety gwyliau arall a mathau eraill o lety torfol		
+55.3	55	Camping grounds, recreational vehicle parks and trailer parks			
+55.30	55.3	Recreational vehicle parks, trailer parks and camping grounds	Parciau cerbydau hamdden, parciau trelars a meysydd gwersylla		
+55.9	55	Other accommodation			
+55.90	55.9	Other accommodation	Llety arall		
 56	I	Food and beverage service activities			
-561	56	Restaurants and mobile food service activities			
-56100	561	Restaurants and mobile food service activities			
-56101	56100	Licenced restaurants	Tai bwyta trwyddedig		
-56102	56100	Unlicenced restaurants and cafes	Tai bwyta a chaffis didrwydded		
-56103	56100	Take-away food shops and mobile food stands	Siopau prydau parod a stondinau bwyd symudol		
-562	56	Event catering and other food service activities			
-56210	562	Event catering activities	Gweithgareddau arlwyo ar gyfer digwyddiadau		
-56290	562	Other food services	Gwasanaethau bwyd eraill		
-563	56	Beverage serving activities			
-56300	563	Beverage serving activities			
-56301	56300	Licenced clubs	Clybiau trwyddedig		
-56302	56300	Public houses and bars	Tafarndai  a bariau		
+56.1	56	Restaurants and mobile food service activities			
+56.10	56.1	Restaurants and mobile food service activities			
+56.10/1	56.10	Licenced restaurants	Tai bwyta trwyddedig		
+56.10/2	56.10	Unlicenced restaurants and cafes	Tai bwyta a chaffis didrwydded		
+56.10/3	56.10	Take-away food shops and mobile food stands	Siopau prydau parod a stondinau bwyd symudol		
+56.2	56	Event catering and other food service activities			
+56.21	56.2	Event catering activities	Gweithgareddau arlwyo ar gyfer digwyddiadau		
+56.29	56.2	Other food services	Gwasanaethau bwyd eraill		
+56.3	56	Beverage serving activities			
+56.30	56.3	Beverage serving activities			
+56.30/1	56.30	Licenced clubs	Clybiau trwyddedig		
+56.30/2	56.30	Public houses and bars	Tafarndai  a bariau		
 58	J	Publishing activities			
-581	58	Publishing of books, periodicals and other publishing activities			
-58110	581	Book publishing	Cyhoeddi llyfrau		
-58120	581	Publishing of directories and mailing lists	Cyhoeddi cyfeirlyfrau a rhestrau postio		
-58130	581	Publishing of newspapers	Cyhoeddi papurau newydd		
-58140	581	Publishing of journals and periodicals			
-58141	58140	Publishing of learned journals	Cyhoeddi cyfnodolion dysgedig		
-58142	58140	Publishing of  consumer and business journals and periodicals	Cyhoeddi cyfnodolion a newyddiaduron i ddefnyddwyr a busnesau		
-58190	581	Other publishing activities	Gweithgareddau cyhoeddi eraill		
-582	58	Software publishing			
-58210	582	Publishing of computer games	Cyhoeddi gemau cyfrifiadur		
-58290	582	Other software publishing	Cyhoeddi meddalwedd arall		
+58.1	58	Publishing of books, periodicals and other publishing activities			
+58.11	58.1	Book publishing	Cyhoeddi llyfrau		
+58.12	58.1	Publishing of directories and mailing lists	Cyhoeddi cyfeirlyfrau a rhestrau postio		
+58.13	58.1	Publishing of newspapers	Cyhoeddi papurau newydd		
+58.14	58.1	Publishing of journals and periodicals			
+58.14/1	58.14	Publishing of learned journals	Cyhoeddi cyfnodolion dysgedig		
+58.14/2	58.14	Publishing of  consumer and business journals and periodicals	Cyhoeddi cyfnodolion a newyddiaduron i ddefnyddwyr a busnesau		
+58.19	58.1	Other publishing activities	Gweithgareddau cyhoeddi eraill		
+58.2	58	Software publishing			
+58.21	58.2	Publishing of computer games	Cyhoeddi gemau cyfrifiadur		
+58.29	58.2	Other software publishing	Cyhoeddi meddalwedd arall		
 59	J	Motion picture, video and television programme production, sound recording and music publishing activities			
-591	59	Motion picture, video and television programme activities			
-59110	591	Motion picture, video and television programme production activities			
-59111	59110	Motion picture production activities	Gweithgareddau cynhyrchu ffilmiau		
-59112	59110	Video production activities	Gweithgareddau cynhyrchu fideo		
-59113	59110	Television programme production activities	Gweithgareddau cynhyrchu rhaglenni teledu		
-59120	591	Motion picture, video and television programme post-production activities	Gweithgareddau ôl-gynhyrchu ar gyfer ffilmiau, fideo a rhaglenni teledu		
-59130	591	Motion picture, video and television programme distribution activities			
-59131	59130	Motion picture distribution activities	Gweithgareddau dosbarthu ffilmiau		
-59132	59130	Video distribution activities	Gweithgareddau dosbarthu fideo		
-59133	59130	Television programme distribution activities	Gweithgareddau dosbarthu rhaglenni teledu		
-59140	591	Motion picture projection activities	Gweithgareddau taflunio ffilmiau		
-592	59	Sound recording and music publishing activities			
-59200	592	Sound recording and music publishing activities	Gweithgareddau recordio sain a chyhoeddi cerddoriaeth		
+59.1	59	Motion picture, video and television programme activities			
+59.11	59.1	Motion picture, video and television programme production activities			
+59.11/1	59.11	Motion picture production activities	Gweithgareddau cynhyrchu ffilmiau		
+59.11/2	59.11	Video production activities	Gweithgareddau cynhyrchu fideo		
+59.11/3	59.11	Television programme production activities	Gweithgareddau cynhyrchu rhaglenni teledu		
+59.12	59.1	Motion picture, video and television programme post-production activities	Gweithgareddau ôl-gynhyrchu ar gyfer ffilmiau, fideo a rhaglenni teledu		
+59.13	59.1	Motion picture, video and television programme distribution activities			
+59.13/1	59.13	Motion picture distribution activities	Gweithgareddau dosbarthu ffilmiau		
+59.13/2	59.13	Video distribution activities	Gweithgareddau dosbarthu fideo		
+59.13/3	59.13	Television programme distribution activities	Gweithgareddau dosbarthu rhaglenni teledu		
+59.14	59.1	Motion picture projection activities	Gweithgareddau taflunio ffilmiau		
+59.2	59	Sound recording and music publishing activities			
+59.20	59.2	Sound recording and music publishing activities	Gweithgareddau recordio sain a chyhoeddi cerddoriaeth		
 60	J	Programming and broadcasting activities			
-601	60	Radio broadcasting			
-60100	601	Radio broadcasting	Darlledu ar y radio		
-602	60	Television programming and broadcasting activities			
-60200	602	Television programming and broadcasting activities	Gweithgareddau rhaglennu a darlledu ar y teledu		
+60.1	60	Radio broadcasting			
+60.10	60.1	Radio broadcasting	Darlledu ar y radio		
+60.2	60	Television programming and broadcasting activities			
+60.20	60.2	Television programming and broadcasting activities	Gweithgareddau rhaglennu a darlledu ar y teledu		
 61	J	Telecommunications			
-611	61	Wired telecommunications activities			
-61100	611	Wired telecommunications activities	Gweithgareddau telathrebu â gwifrau		
-612	61	Wireless telecommunications activities			
-61200	612	Wireless telecommunications activities	Gweithgareddau telathrebu diwifr		
-613	61	Satellite telecommunications activities			
-61300	613	Satellite telecommunications activities	Gweithgareddau telathrebu drwy loeren		
-619	61	Other telecommunications activities			
-61900	619	Other telecommunications activities	Gweithgareddau telathrebu eraill		
+61.1	61	Wired telecommunications activities			
+61.10	61.1	Wired telecommunications activities	Gweithgareddau telathrebu â gwifrau		
+61.2	61	Wireless telecommunications activities			
+61.20	61.2	Wireless telecommunications activities	Gweithgareddau telathrebu diwifr		
+61.3	61	Satellite telecommunications activities			
+61.30	61.3	Satellite telecommunications activities	Gweithgareddau telathrebu drwy loeren		
+61.9	61	Other telecommunications activities			
+61.90	61.9	Other telecommunications activities	Gweithgareddau telathrebu eraill		
 62	J	Computer programming, consultancy and related activities			
-620	62	Computer programming, consultancy and related activities			
-62010	620	Computer programming activities			
-62011	62010	Ready-made interactive leisure and entertainment software development	Datblygu meddalwedd hamdden ac adloniant ryngweithiol barod		
-62012	62010	Business and domestic software development	Datblygu meddalwedd busnes a domestig		
-62020	620	Information technology consultancy activities	Gweithgareddau ymgynghoriaeth ym maes technoleg gwybodaeth		
-62030	620	Computer facilities management activities	Gweithgareddau rheoli cyfleusterau cyfrifiadurol		
-62090	620	Other information technology service activities	Gweithgareddau eraill ym maes gwasanaethau technoleg gwybodaeth		
+62.0	62	Computer programming, consultancy and related activities			
+62.01	62.0	Computer programming activities			
+62.01/1	62.01	Ready-made interactive leisure and entertainment software development	Datblygu meddalwedd hamdden ac adloniant ryngweithiol barod		
+62.01/2	62.01	Business and domestic software development	Datblygu meddalwedd busnes a domestig		
+62.02	62.0	Information technology consultancy activities	Gweithgareddau ymgynghoriaeth ym maes technoleg gwybodaeth		
+62.03	62.0	Computer facilities management activities	Gweithgareddau rheoli cyfleusterau cyfrifiadurol		
+62.09	62.0	Other information technology service activities	Gweithgareddau eraill ym maes gwasanaethau technoleg gwybodaeth		
 63	J	Information service activities			
-631	63	Data processing, hosting and related activities; web portals			
-63110	631	Data processing, hosting and related activities	Prosesu a lletya data a gweithgareddau cysylltiedig		
-63120	631	Web portals	Pyrth ar y we		
-639	63	Other information service activities			
-63910	639	News agency activities	Gweithgareddau asiantaethau newyddion		
-63990	639	Other information service activities not elsewhere classified	Gweithgareddau gwasanaethau gwybodaeth eraill n.dd.b.		
+63.1	63	Data processing, hosting and related activities; web portals			
+63.11	63.1	Data processing, hosting and related activities	Prosesu a lletya data a gweithgareddau cysylltiedig		
+63.12	63.1	Web portals	Pyrth ar y we		
+63.9	63	Other information service activities			
+63.91	63.9	News agency activities	Gweithgareddau asiantaethau newyddion		
+63.99	63.9	Other information service activities not elsewhere classified	Gweithgareddau gwasanaethau gwybodaeth eraill n.dd.b.		
 64	K	Financial service activities, except insurance and pension funding			
-641	64	Monetary intermediation			
-64110	641	Central banking	Bancio canolog		
-64190	641	Other monetary intermediation			
-64191	64190	Banks	Banciau		
-64192	64190	Building societies	Cymdeithasau adeiladu		
-642	64	Activities of holding companies			
-64200	642	Activities of holding companies			
-64201	64200	Activities of agricultural holding companies	Gweithgareddau cwmnïau daliannol ym maes amaeth		
-64202	64200	Activities of production holding companies	Gweithgareddau cwmnïau daliannol ym maes cynhyrchu		
-64203	64200	Activities of construction holding companies	Gweithgareddau cwmnïau daliannol ym maes adeiladu		
-64204	64200	Activities of distribution holding companies	Gweithgareddau cwmnïau daliannol ym maes dosbarthu		
-64205	64200	Activities of financial services holding companies	Gweithgareddau cwmnïau daliannol ym maes gwasanaethau ariannol		
-64209	64200	Activities of other holding companies not elsewhere classified	Gweithgareddau cwmnïau daliannol eraill n.dd.b.		
-643	64	Trusts, funds and similar financial entities			
-64300	643	Trusts, funds and similar financial entities			
-64301	64300	Activities of investment trusts	Gweithgareddau ymddiriedolaethau buddsoddi		
-64302	64300	Activities of unit trusts	Gweithgareddau ymddiriedolaethau unedol		
-64303	64300	Activities of venture and development capital companies	Gweithgareddau cwmnïau cyfalaf mentro a datblygu		
-64304	64300	Activities of open-ended investment companies	Gweithgareddau cwmnïau buddsoddi penagored		
-64305	64300	Activities of property unit trusts	Gweithgareddau ymddiriedolaethau eiddo unedol		
-64306	64300	Activities of real estate investment trusts	Gweithgareddau ymddiriedolaethau buddsoddi mewn eiddo diriaethol		
-649	64	Other financial service activities, except insurance and pension funding			
-64910	649	Financial leasing	Prydlesu ariannol		
-64920	649	Other credit granting			
-64921	64920	Credit granting by non-deposit taking finance houses and other specialist consumer credit grantors	Ariandai sy'n rhoi credyd nad ydynt yn cymryd adnau a darparwyr credyd arbenigol eraill i ddefnyddwyr		
-64922	64920	Activities of mortgage finance companies	Gweithgareddau cwmnïau ariannu morgeisi		
-64929	64920	Other credit granting not elsewhere classified	Darparwyr credyd eraill n.dd.b.		
-64990	649	Other financial service activities, except insurance and pension funding, not elsewhere classified			
-64991	64990	Security dealing on own account	Gwerthu gwarannau ar ei gyfrif ei hun		
-64992	64990	Factoring	Asiantau masnachol		
-64999	64990	Financial intermediation not elsewhere classified	Mathau eraill o ryngoli ariannol na ddosbarthwyd fel arall		
+64.1	64	Monetary intermediation			
+64.11	64.1	Central banking	Bancio canolog		
+64.19	64.1	Other monetary intermediation			
+64.19/1	64.19	Banks	Banciau		
+64.19/2	64.19	Building societies	Cymdeithasau adeiladu		
+64.2	64	Activities of holding companies			
+64.20	64.2	Activities of holding companies			
+64.20/1	64.20	Activities of agricultural holding companies	Gweithgareddau cwmnïau daliannol ym maes amaeth		
+64.20/2	64.20	Activities of production holding companies	Gweithgareddau cwmnïau daliannol ym maes cynhyrchu		
+64.20/3	64.20	Activities of construction holding companies	Gweithgareddau cwmnïau daliannol ym maes adeiladu		
+64.20/4	64.20	Activities of distribution holding companies	Gweithgareddau cwmnïau daliannol ym maes dosbarthu		
+64.20/5	64.20	Activities of financial services holding companies	Gweithgareddau cwmnïau daliannol ym maes gwasanaethau ariannol		
+64.20/9	64.20	Activities of other holding companies not elsewhere classified	Gweithgareddau cwmnïau daliannol eraill n.dd.b.		
+64.3	64	Trusts, funds and similar financial entities			
+64.30	64.3	Trusts, funds and similar financial entities			
+64.30/1	64.30	Activities of investment trusts	Gweithgareddau ymddiriedolaethau buddsoddi		
+64.30/2	64.30	Activities of unit trusts	Gweithgareddau ymddiriedolaethau unedol		
+64.30/3	64.30	Activities of venture and development capital companies	Gweithgareddau cwmnïau cyfalaf mentro a datblygu		
+64.30/4	64.30	Activities of open-ended investment companies	Gweithgareddau cwmnïau buddsoddi penagored		
+64.30/5	64.30	Activities of property unit trusts	Gweithgareddau ymddiriedolaethau eiddo unedol		
+64.30/6	64.30	Activities of real estate investment trusts	Gweithgareddau ymddiriedolaethau buddsoddi mewn eiddo diriaethol		
+64.9	64	Other financial service activities, except insurance and pension funding			
+64.91	64.9	Financial leasing	Prydlesu ariannol		
+64.92	64.9	Other credit granting			
+64.92/1	64.92	Credit granting by non-deposit taking finance houses and other specialist consumer credit grantors	Ariandai sy'n rhoi credyd nad ydynt yn cymryd adnau a darparwyr credyd arbenigol eraill i ddefnyddwyr		
+64.92/2	64.92	Activities of mortgage finance companies	Gweithgareddau cwmnïau ariannu morgeisi		
+64.92/9	64.92	Other credit granting not elsewhere classified	Darparwyr credyd eraill n.dd.b.		
+64.99	64.9	Other financial service activities, except insurance and pension funding, not elsewhere classified			
+64.99/1	64.99	Security dealing on own account	Gwerthu gwarannau ar ei gyfrif ei hun		
+64.99/2	64.99	Factoring	Asiantau masnachol		
+64.99/9	64.99	Financial intermediation not elsewhere classified	Mathau eraill o ryngoli ariannol na ddosbarthwyd fel arall		
 65	K	Insurance, reinsurance and pension funding, except compulsory social security			
-651	65	Insurance			
-65110	651	Life insurance	Yswiriant bywyd		
-65120	651	Non-life insurance	Yswiriant nad yw'n yswiriant bywyd		
-652	65	Reinsurance			
-65200	652	Reinsurance			
-65201	65200	Life reinsurance	Ailyswirio bywydau		
-65202	65200	Non-life reinsurance	Ailyswirio pethau heblaw bywyd		
-653	65	Pension funding			
-65300	653	Pension funding	Ariannu pensiynau		
+65.1	65	Insurance			
+65.11	65.1	Life insurance	Yswiriant bywyd		
+65.12	65.1	Non-life insurance	Yswiriant nad yw'n yswiriant bywyd		
+65.2	65	Reinsurance			
+65.20	65.2	Reinsurance			
+65.20/1	65.20	Life reinsurance	Ailyswirio bywydau		
+65.20/2	65.20	Non-life reinsurance	Ailyswirio pethau heblaw bywyd		
+65.3	65	Pension funding			
+65.30	65.3	Pension funding	Ariannu pensiynau		
 66	K	Activities auxiliary to financial services and insurance activities			
-661	66	Activities auxiliary to financial services, except insurance and pension funding			
-66110	661	Administration of financial markets	Gweinyddu marchnadoedd ariannol		
-66120	661	Security and commodity contracts dealing activities	Gweithgareddau masnachu contractau nwyddau a gwarannau		
-66190	661	Activities auxiliary to financial intermediation not elsewhere classified	Gweithgareddau atodol o ran rhyngoli ariannol n.dd.b.		
-662	66	Activities auxiliary to insurance and pension funding			
-66210	662	Risk and damage evaluation	Gwerthuso risg a difrod		
-66220	662	Activities of insurance agents and brokers	Gweithgareddau asiantau a broceriaid yswiriant		
-66290	662	Other activities auxiliary to insurance and pension funding	Gweithgareddau atodol eraill ym maes ariannu yswiriant a phensiynau		
-663	66	Fund management activities			
-66300	663	Fund management activities	Gweithgareddau rheoli cronfeydd		
+66.1	66	Activities auxiliary to financial services, except insurance and pension funding			
+66.11	66.1	Administration of financial markets	Gweinyddu marchnadoedd ariannol		
+66.12	66.1	Security and commodity contracts dealing activities	Gweithgareddau masnachu contractau nwyddau a gwarannau		
+66.19	66.1	Activities auxiliary to financial intermediation not elsewhere classified	Gweithgareddau atodol o ran rhyngoli ariannol n.dd.b.		
+66.2	66	Activities auxiliary to insurance and pension funding			
+66.21	66.2	Risk and damage evaluation	Gwerthuso risg a difrod		
+66.22	66.2	Activities of insurance agents and brokers	Gweithgareddau asiantau a broceriaid yswiriant		
+66.29	66.2	Other activities auxiliary to insurance and pension funding	Gweithgareddau atodol eraill ym maes ariannu yswiriant a phensiynau		
+66.3	66	Fund management activities			
+66.30	66.3	Fund management activities	Gweithgareddau rheoli cronfeydd		
 68	L	Real estate activities			
-681	68	Buying and selling of own real estate			
-68100	681	Buying and selling of own real estate	Prynu a gwerthu eich eiddo diriaethol eich hun		
-682	68	Renting and operating of own or leased real estate			
-68200	682	Renting and operating of own or leased real estate			
-68201	68200	Renting and operating of Housing Association real estate	Rhentu a rheoli eiddo diriaethol Cymdeithas Tai		
-68202	68200	Letting and operating of conference and exhibition centres	Gosod a rheoli canolfannau cynadledda ac arddangos		
-68209	68200	Other letting and operating of own or leased real estate	Gosod a rheoli eich eiddo diriaethol arall eich hun neu ar brydles		
-683	68	Real estate activities on a fee or contract basis			
-68310	683	Real estate agencies	Asiantaethau eiddo diriaethol		
-68320	683	Management of real estate on a fee or contract basis	Rheoli eiddo diriaethol am ffi neu ar gontract		
+68.1	68	Buying and selling of own real estate			
+68.10	68.1	Buying and selling of own real estate	Prynu a gwerthu eich eiddo diriaethol eich hun		
+68.2	68	Renting and operating of own or leased real estate			
+68.20	68.2	Renting and operating of own or leased real estate			
+68.20/1	68.20	Renting and operating of Housing Association real estate	Rhentu a rheoli eiddo diriaethol Cymdeithas Tai		
+68.20/2	68.20	Letting and operating of conference and exhibition centres	Gosod a rheoli canolfannau cynadledda ac arddangos		
+68.20/9	68.20	Other letting and operating of own or leased real estate	Gosod a rheoli eich eiddo diriaethol arall eich hun neu ar brydles		
+68.3	68	Real estate activities on a fee or contract basis			
+68.31	68.3	Real estate agencies	Asiantaethau eiddo diriaethol		
+68.32	68.3	Management of real estate on a fee or contract basis	Rheoli eiddo diriaethol am ffi neu ar gontract		
 69	M	Legal and accounting activities			
-691	69	Legal activities			
-69100	691	Legal activities			
-69101	69100	Barristers at law	Bargyfreithwyr sy'n ymarfer y gyfraith		
-69102	69100	Solicitors	Cyfreithwyr		
-69109	69100	Activities of patent and copyright agents; other legal activities not elsewhere classified	Gweithgareddau asiantau patent a hawlfraint; gweithgareddau cyfreithiol eraill n.dd.b.		
-692	69	Accounting, bookkeeping and auditing activities; tax consultancy			
-69200	692	Accounting, bookkeeping and auditing activities; tax consultancy			
-69201	69200	Accounting and auditing activities	Gweithgareddau cyfrifyddu ac archwilio		
-69202	69200	Bookkeeping activities	Gweithgareddau cadw cyfrifon		
-69203	69200	Tax consultancy	Ymgynghoriaeth ar drethi		
+69.1	69	Legal activities			
+69.10	69.1	Legal activities			
+69.10/1	69.10	Barristers at law	Bargyfreithwyr sy'n ymarfer y gyfraith		
+69.10/2	69.10	Solicitors	Cyfreithwyr		
+69.10/9	69.10	Activities of patent and copyright agents; other legal activities not elsewhere classified	Gweithgareddau asiantau patent a hawlfraint; gweithgareddau cyfreithiol eraill n.dd.b.		
+69.2	69	Accounting, bookkeeping and auditing activities; tax consultancy			
+69.20	69.2	Accounting, bookkeeping and auditing activities; tax consultancy			
+69.20/1	69.20	Accounting and auditing activities	Gweithgareddau cyfrifyddu ac archwilio		
+69.20/2	69.20	Bookkeeping activities	Gweithgareddau cadw cyfrifon		
+69.20/3	69.20	Tax consultancy	Ymgynghoriaeth ar drethi		
 70	M	Activities of head offices; management consultancy activities			
-701	70	Activities of head offices			
-70100	701	Activities of head offices	Gweithgareddau pencadlysoedd		
-702	70	Management consultancy activities			
-70210	702	Public relations and communications activities	Gweithgareddau cysylltiadau cyhoeddus a chyfathrebu		
-70220	702	Business and other management consultancy activities			
-70221	70220	Financial management	Rheolaeth ariannol		
-70229	70220	Management consultancy activities other than financial management	Gweithgareddau ymgynghoriaeth ar faterion rheoli ac eithrio rheolaeth ariannol		
+70.1	70	Activities of head offices			
+70.10	70.1	Activities of head offices	Gweithgareddau pencadlysoedd		
+70.2	70	Management consultancy activities			
+70.21	70.2	Public relations and communications activities	Gweithgareddau cysylltiadau cyhoeddus a chyfathrebu		
+70.22	70.2	Business and other management consultancy activities			
+70.22/1	70.22	Financial management	Rheolaeth ariannol		
+70.22/9	70.22	Management consultancy activities other than financial management	Gweithgareddau ymgynghoriaeth ar faterion rheoli ac eithrio rheolaeth ariannol		
 71	M	Architectural and engineering activities; technical testing and analysis			
-711	71	Architectural and engineering activities and related technical consultancy			
-71110	711	Architectural activities			
-71111	71110	Architectural activities	Gweithgareddau pensaernïol		
-71112	71110	Urban planning and landscape architectural activities	Gweithgareddau cynllunio trefol a phensaernïaeth y dirwedd		
-71120	711	Engineering activities and related technical consultancy			
-71121	71120	Engineering design activities for industrial process and production	Gweithgareddau dylunio peirianneg ar gyfer prosesau a chynhyrchu diwydiannol		
-71122	71120	Engineering related scientific and technical consulting activities	Gweithgareddau ymgynghori gwyddonol a thechnegol ym maes peirianneg		
-71129	71120	Other engineering activities	Gweithgareddau peirianneg eraill		
-712	71	Technical testing and analysis			
-71200	712	Technical testing and analysis	Profi a dadansoddi technegol		
+71.1	71	Architectural and engineering activities and related technical consultancy			
+71.11	71.1	Architectural activities			
+71.11/1	71.11	Architectural activities	Gweithgareddau pensaernïol		
+71.11/2	71.11	Urban planning and landscape architectural activities	Gweithgareddau cynllunio trefol a phensaernïaeth y dirwedd		
+71.12	71.1	Engineering activities and related technical consultancy			
+71.12/1	71.12	Engineering design activities for industrial process and production	Gweithgareddau dylunio peirianneg ar gyfer prosesau a chynhyrchu diwydiannol		
+71.12/2	71.12	Engineering related scientific and technical consulting activities	Gweithgareddau ymgynghori gwyddonol a thechnegol ym maes peirianneg		
+71.12/9	71.12	Other engineering activities	Gweithgareddau peirianneg eraill		
+71.2	71	Technical testing and analysis			
+71.20	71.2	Technical testing and analysis	Profi a dadansoddi technegol		
 72	M	Scientific research and development			
-721	72	Research and experimental development on natural sciences and engineering			
-72110	721	Research and experimental development on biotechnology	Gwaith ymchwil a datblygu arbrofol ym maes biodechnoleg		
-72190	721	Other research and experimental development on natural sciences and engineering	Gwaith ymchwil a datblygu arbrofol arall ym maes peirianneg a'r gwyddorau natur		
-722	72	Research and experimental development on social sciences and humanities			
-72200	722	Research and experimental development on social sciences and humanities	Gwaith ymchwil a datblygu arbrofol ym maes y gwyddorau cymdeithasol a'r dyniaethau		
+72.1	72	Research and experimental development on natural sciences and engineering			
+72.11	72.1	Research and experimental development on biotechnology	Gwaith ymchwil a datblygu arbrofol ym maes biodechnoleg		
+72.19	72.1	Other research and experimental development on natural sciences and engineering	Gwaith ymchwil a datblygu arbrofol arall ym maes peirianneg a'r gwyddorau natur		
+72.2	72	Research and experimental development on social sciences and humanities			
+72.20	72.2	Research and experimental development on social sciences and humanities	Gwaith ymchwil a datblygu arbrofol ym maes y gwyddorau cymdeithasol a'r dyniaethau		
 73	M	Advertising and market research			
-731	73	Advertising			
-73110	731	Advertising agencies	Asiantaethau hysbysebu		
-73120	731	Media representation services	Gwasanaethau cynrychiolaeth ym maes y cyfryngau		
-732	73	Market research and public opinion polling			
-73200	732	Market research and public opinion polling	Ymchwil i'r farchnad ac arolygon barn		
+73.1	73	Advertising			
+73.11	73.1	Advertising agencies	Asiantaethau hysbysebu		
+73.12	73.1	Media representation services	Gwasanaethau cynrychiolaeth ym maes y cyfryngau		
+73.2	73	Market research and public opinion polling			
+73.20	73.2	Market research and public opinion polling	Ymchwil i'r farchnad ac arolygon barn		
 74	M	Other professional, scientific and technical activities			
-741	74	Specialised design activities			
-74100	741	specialised design activities	Gweithgareddau dylunio arbenigol		
-742	74	Photographic activities			
-74200	742	Photographic activities			
-74201	74200	Portrait photographic activities	Gweithgareddau portreadu ffotograffig		
-74202	74200	Other specialist photography	Mathau eraill o ffotograffiaeth arbenigol		
-74203	74200	Film processing	Prosesu ffilmiau		
-74209	74200	Photographic activities not elsewhere classified	Gweithgareddau ffotograffig na ddosbarthwyd yn benodol		
-743	74	Translation and interpretation activities			
-74300	743	Translation and interpretation activities	Gweithgareddau cyfieithu a chyfieithu ar y pryd		
-749	74	Other professional, scientific and technical activities not elsewhere classified			
-74900	749	Other professional, scientific and technical activities not elsewhere classified			
-74901	74900	Environmental consulting activities	Gweithgareddau ymgynghori amgylcheddol		
-74902	74900	Quantity surveying activities	Gweithgareddau mesur meintiau		
-74909	74900	Other professional, scientific and technical activities not elsewhere classified	Gweithgareddau proffesiynol, gwyddonol a thechnegol n.dd.b.		
+74.1	74	Specialised design activities			
+74.10	74.1	specialised design activities	Gweithgareddau dylunio arbenigol		
+74.2	74	Photographic activities			
+74.20	74.2	Photographic activities			
+74.20/1	74.20	Portrait photographic activities	Gweithgareddau portreadu ffotograffig		
+74.20/2	74.20	Other specialist photography	Mathau eraill o ffotograffiaeth arbenigol		
+74.20/3	74.20	Film processing	Prosesu ffilmiau		
+74.20/9	74.20	Photographic activities not elsewhere classified	Gweithgareddau ffotograffig na ddosbarthwyd yn benodol		
+74.3	74	Translation and interpretation activities			
+74.30	74.3	Translation and interpretation activities	Gweithgareddau cyfieithu a chyfieithu ar y pryd		
+74.9	74	Other professional, scientific and technical activities not elsewhere classified			
+74.90	74.9	Other professional, scientific and technical activities not elsewhere classified			
+74.90/1	74.90	Environmental consulting activities	Gweithgareddau ymgynghori amgylcheddol		
+74.90/2	74.90	Quantity surveying activities	Gweithgareddau mesur meintiau		
+74.90/9	74.90	Other professional, scientific and technical activities not elsewhere classified	Gweithgareddau proffesiynol, gwyddonol a thechnegol n.dd.b.		
 75	M	Veterinary activities			
-750	75	Veterinary activities			
-75000	750	Veterinary activities	Gweithgareddau milfeddygol		
+75.0	75	Veterinary activities			
+75.00	75.0	Veterinary activities	Gweithgareddau milfeddygol		
 77	N	Rental and leasing activities			
-771	77	Renting and leasing of motor vehicles			
-77110	771	Renting and leasing of cars and light motor vehicles	Rhentu a phrydlesu ceir a cherbydau modur ysgafn		
-77120	771	Renting and leasing of trucks and other heavy vehicles	Rhentu a phrydlesu tryciau a cherbydau trwm eraill		
-772	77	Renting and leasing of personal and household goods			
-77210	772	Renting and leasing of recreational and sports goods	Rhentu a phrydlesu nwyddau hamdden a chwaraeon		
-77220	772	Renting of video tapes and disks	Rhentu tapiau a disgiau fideo		
-77290	772	Renting and leasing of other personal and household goods			
-77291	77290	Renting and leasing of media entertainment equipment	Rhentu a phrydlesu cyfarpar y cyfryngau adloniant		
-77299	77290	Renting and leasing of other personal and household goods	Rhentu a phrydlesu nwyddau personol a chartref eraill		
-773	77	Renting and leasing of other machinery, equipment and tangible goods			
-77310	773	Renting and leasing of agricultural machinery and equipment	Rhentu a phrydlesu peiriannau a chyfarpar amaethyddol		
-77320	773	Renting and leasing of construction and civil engineering machinery and equipment	Rhentu a phrydlesu peiriannau a chyfarpar adeiladu a pheirianneg sifil		
-77330	773	Renting and leasing of office machinery and equipment (including computers)	Rhentu a phrydlesu peiriannau a chyfarpar swyddfa (gan gynnwys cyfrifiaduron)		
-77340	773	Renting and leasing of water transport equipment			
-77341	77340	Renting and leasing of passenger water transport equipment	Rhentu a phrydlesu cyfarpar i gludo teithwyr ar y dŵr		
-77342	77340	Renting and leasing of freight water transport equipment	Rhentu a phrydlesu cyfarpar i gludo nwyddau ar y dŵr		
-77350	773	Renting and leasing of air transport equipment			
-77351	77350	Renting and leasing of air passenger transport equipment	Rhentu a phrydlesu cyfarpar i gludo teithwyr yn yr awyr		
-77352	77350	Renting and leasing of freight air transport equipment	Rhentu a phrydlesu cyfarpar i gludo nwyddau yn yr awyr		
-77390	773	Renting and leasing of other machinery, equipment and tangible goods not elsewhere classified	Rhentu a phrydlesu peiriannau, cyfarpar a nwyddau diriaethol eraill n.dd.b.		
-774	77	Leasing of intellectual property and similar products, except copyrighted works			
-77400	774	Leasing of intellectual property and similar products, except copyright works	Prydlesu eiddo deallusol a chynnyrch tebyg, ac eithrio gwaith hawlfraint		
+77.1	77	Renting and leasing of motor vehicles			
+77.11	77.1	Renting and leasing of cars and light motor vehicles	Rhentu a phrydlesu ceir a cherbydau modur ysgafn		
+77.12	77.1	Renting and leasing of trucks and other heavy vehicles	Rhentu a phrydlesu tryciau a cherbydau trwm eraill		
+77.2	77	Renting and leasing of personal and household goods			
+77.21	77.2	Renting and leasing of recreational and sports goods	Rhentu a phrydlesu nwyddau hamdden a chwaraeon		
+77.22	77.2	Renting of video tapes and disks	Rhentu tapiau a disgiau fideo		
+77.29	77.2	Renting and leasing of other personal and household goods			
+77.29/1	77.29	Renting and leasing of media entertainment equipment	Rhentu a phrydlesu cyfarpar y cyfryngau adloniant		
+77.29/9	77.29	Renting and leasing of other personal and household goods	Rhentu a phrydlesu nwyddau personol a chartref eraill		
+77.3	77	Renting and leasing of other machinery, equipment and tangible goods			
+77.31	77.3	Renting and leasing of agricultural machinery and equipment	Rhentu a phrydlesu peiriannau a chyfarpar amaethyddol		
+77.32	77.3	Renting and leasing of construction and civil engineering machinery and equipment	Rhentu a phrydlesu peiriannau a chyfarpar adeiladu a pheirianneg sifil		
+77.33	77.3	Renting and leasing of office machinery and equipment (including computers)	Rhentu a phrydlesu peiriannau a chyfarpar swyddfa (gan gynnwys cyfrifiaduron)		
+77.34	77.3	Renting and leasing of water transport equipment			
+77.34/1	77.34	Renting and leasing of passenger water transport equipment	Rhentu a phrydlesu cyfarpar i gludo teithwyr ar y dŵr		
+77.34/2	77.34	Renting and leasing of freight water transport equipment	Rhentu a phrydlesu cyfarpar i gludo nwyddau ar y dŵr		
+77.35	77.3	Renting and leasing of air transport equipment			
+77.35/1	77.35	Renting and leasing of air passenger transport equipment	Rhentu a phrydlesu cyfarpar i gludo teithwyr yn yr awyr		
+77.35/2	77.35	Renting and leasing of freight air transport equipment	Rhentu a phrydlesu cyfarpar i gludo nwyddau yn yr awyr		
+77.39	77.3	Renting and leasing of other machinery, equipment and tangible goods not elsewhere classified	Rhentu a phrydlesu peiriannau, cyfarpar a nwyddau diriaethol eraill n.dd.b.		
+77.4	77	Leasing of intellectual property and similar products, except copyrighted works			
+77.40	77.4	Leasing of intellectual property and similar products, except copyright works	Prydlesu eiddo deallusol a chynnyrch tebyg, ac eithrio gwaith hawlfraint		
 78	N	Employment activities			
-781	78	Activities of employment placement agencies			
-78100	781	Activities of employment placement agencies			
-78101	78100	Motion picture, television and other theatrical casting activities	Gweithgareddau castio ar gyfer ffilmiau, y teledu a gweithgareddau theatraidd eraill		
-78109	78100	Other activities of employment placement agencies	Gweithgareddau eraill asiantaethau canfod cyflogaeth		
-782	78	Temporary employment agency activities			
-78200	782	Temporary employment agency activities	Gweithgareddau asiantaethau canfod cyflogaeth dros dro		
-783	78	Other human resources provision			
-78300	783	Human resources provision and management of human resources functions	Darparu gwasanaethau adnoddau dynol a rheoli swyddogaethau adnoddau dynol		
+78.1	78	Activities of employment placement agencies			
+78.10	78.1	Activities of employment placement agencies			
+78.10/1	78.10	Motion picture, television and other theatrical casting activities	Gweithgareddau castio ar gyfer ffilmiau, y teledu a gweithgareddau theatraidd eraill		
+78.10/9	78.10	Other activities of employment placement agencies	Gweithgareddau eraill asiantaethau canfod cyflogaeth		
+78.2	78	Temporary employment agency activities			
+78.20	78.2	Temporary employment agency activities	Gweithgareddau asiantaethau canfod cyflogaeth dros dro		
+78.3	78	Other human resources provision			
+78.30	78.3	Human resources provision and management of human resources functions	Darparu gwasanaethau adnoddau dynol a rheoli swyddogaethau adnoddau dynol		
 79	N	Travel agency, tour operator and other reservation service and related activities			
-791	79	Travel agency and tour operator activities			
-79110	791	Travel agency activities	Gweithgareddau asiantaethau teithio		
-79120	791	Tour operator activities	Gweithgareddau trefnwyr teithiau		
-799	79	Other reservation service and related activities			
-79900	799	Other reservation service and related activities			
-79901	79900	Activities of tourist guides	Gweithgareddau tywyswyr twristiaid		
-79909	79900	Other reservation service activities not elsewhere classified	Gweithgareddau gwasanaethau bwcio a chadw eraill n.dd.b.		
+79.1	79	Travel agency and tour operator activities			
+79.11	79.1	Travel agency activities	Gweithgareddau asiantaethau teithio		
+79.12	79.1	Tour operator activities	Gweithgareddau trefnwyr teithiau		
+79.9	79	Other reservation service and related activities			
+79.90	79.9	Other reservation service and related activities			
+79.90/1	79.90	Activities of tourist guides	Gweithgareddau tywyswyr twristiaid		
+79.90/9	79.90	Other reservation service activities not elsewhere classified	Gweithgareddau gwasanaethau bwcio a chadw eraill n.dd.b.		
 80	N	Security and investigation activities			
-801	80	Private security activities			
-80100	801	Private security activities	Gweithgareddau diogelwch preifat		
-802	80	Security systems service activities			
-80200	802	Security systems service activities	Gweithgareddau gwasanaethau systemau diogelwch		
-803	80	Investigation activities			
-80300	803	Investigation activities	Gwasanaethau ymholi		
+80.1	80	Private security activities			
+80.10	80.1	Private security activities	Gweithgareddau diogelwch preifat		
+80.2	80	Security systems service activities			
+80.20	80.2	Security systems service activities	Gweithgareddau gwasanaethau systemau diogelwch		
+80.3	80	Investigation activities			
+80.30	80.3	Investigation activities	Gwasanaethau ymholi		
 81	N	Services to buildings and landscape activities			
-811	81	Combined facilities support activities			
-81100	811	Combined facilities support activities	Gweithgareddau cynnal cyfleusterau cyfunol		
-812	81	Cleaning activities			
-81210	812	General cleaning of buildings	Glanhau cyffredinol mewn adeiladau		
-81220	812	Other building and industrial cleaning activities			
-81221	81220	Window cleaning services	Gwasanaethau glanhau ffenestri		
-81222	81220	Specialised cleaning services	Gwasanaethau glanhau arbenigol		
-81223	81220	Furnace and chimney cleaning services	Gwasanaethau glanhau ffwrneisi a simneiau		
-81229	81220	Other building and industrial cleaning activities	Gweithgareddau eraill ym maes glanhau adeiladau a glanhau diwydiannol		
-81290	812	Other cleaning activities			
-81291	81290	Disinfecting and exterminating services	Gweithgareddau diheintio a difodi		
-81299	81290	Other cleaning services	Gwasanaethau glanhau eraill		
-813	81	Landscape service activities			
-81300	813	Landscape service activities	Gweithgareddau gwasanaethau'r dirwedd		
+81.1	81	Combined facilities support activities			
+81.10	81.1	Combined facilities support activities	Gweithgareddau cynnal cyfleusterau cyfunol		
+81.2	81	Cleaning activities			
+81.21	81.2	General cleaning of buildings	Glanhau cyffredinol mewn adeiladau		
+81.22	81.2	Other building and industrial cleaning activities			
+81.22/1	81.22	Window cleaning services	Gwasanaethau glanhau ffenestri		
+81.22/2	81.22	Specialised cleaning services	Gwasanaethau glanhau arbenigol		
+81.22/3	81.22	Furnace and chimney cleaning services	Gwasanaethau glanhau ffwrneisi a simneiau		
+81.22/9	81.22	Other building and industrial cleaning activities	Gweithgareddau eraill ym maes glanhau adeiladau a glanhau diwydiannol		
+81.29	81.2	Other cleaning activities			
+81.29/1	81.29	Disinfecting and exterminating services	Gweithgareddau diheintio a difodi		
+81.29/9	81.29	Other cleaning services	Gwasanaethau glanhau eraill		
+81.3	81	Landscape service activities			
+81.30	81.3	Landscape service activities	Gweithgareddau gwasanaethau'r dirwedd		
 82	N	Office administrative, office support and other business support activities			
-821	82	Office administrative and support activities			
-82110	821	Combined office administrative service activities	Gweithgareddau gwasanaethau gweinyddol cyfunol mewn swyddfeydd		
-82190	821	Photocopying, document preparation and other specialised office support activities	Llungopïo, paratoi dogfennau a gweithgareddau cymorth arbenigol eraill ar gyfer swyddfeydd		
-822	82	Activities of call centres			
-82200	822	Activities of call centres	Gweithgareddau canolfannau galwadau		
-823	82	Organisation of conventions and trade shows			
-82300	823	Organisation of conventions and trade shows			
-82301	82300	Activities of exhibition and fair organisers	Gweithgareddau trefnu arddangosfeydd a ffeiriau		
-82302	82300	Activities of conference organisers	Gweithgareddau trefnu cynadleddau		
-829	82	Business support service activities not elsewhere classified			
-82910	829	Activities of collection agencies and credit bureaus			
-82911	82910	Activities of collection agencies	Gweithgareddau asiantaethau casglu		
-82912	82910	Activities of credit bureaus	Gweithgareddau canolfannau credyd		
-82920	829	Packaging activities	Gweithgareddau pecynnu		
-82990	829	Other business support service activities not elsewhere classified	Gweithgareddau gwasanaethau cymorth busnes eraill n.dd.b.		
+82.1	82	Office administrative and support activities			
+82.11	82.1	Combined office administrative service activities	Gweithgareddau gwasanaethau gweinyddol cyfunol mewn swyddfeydd		
+82.19	82.1	Photocopying, document preparation and other specialised office support activities	Llungopïo, paratoi dogfennau a gweithgareddau cymorth arbenigol eraill ar gyfer swyddfeydd		
+82.2	82	Activities of call centres			
+82.20	82.2	Activities of call centres	Gweithgareddau canolfannau galwadau		
+82.3	82	Organisation of conventions and trade shows			
+82.30	82.3	Organisation of conventions and trade shows			
+82.30/1	82.30	Activities of exhibition and fair organisers	Gweithgareddau trefnu arddangosfeydd a ffeiriau		
+82.30/2	82.30	Activities of conference organisers	Gweithgareddau trefnu cynadleddau		
+82.9	82	Business support service activities not elsewhere classified			
+82.91	82.9	Activities of collection agencies and credit bureaus			
+82.91/1	82.91	Activities of collection agencies	Gweithgareddau asiantaethau casglu		
+82.91/2	82.91	Activities of credit bureaus	Gweithgareddau canolfannau credyd		
+82.92	82.9	Packaging activities	Gweithgareddau pecynnu		
+82.99	82.9	Other business support service activities not elsewhere classified	Gweithgareddau gwasanaethau cymorth busnes eraill n.dd.b.		
 84	O	Public administration and defence; compulsory social security			
-841	84	Administration of the State and the economic and social policy of the community			
-84110	841	General public administration activities	Gweithgareddau cyffredinol ym maes gweinyddiaeth gyhoeddus		
-84120	841	Regulation of health care, education, cultural and other social services, not incl. social security	Rheoleiddio gofal iechyd, addysg, diwylliant a gwasanaethau cymdeithasol eraill, heblaw nawdd cymdeithasol		
-84130	841	Regulation of and contribution to more efficient operation of businesses	Rheoleiddio busnesau a'u helpu i weithredu'n fwy effeithlon		
-842	84	Provision of services to the community as a whole			
-84210	842	Foreign affairs	Materion tramor		
-84220	842	Defence activities	Gweithgareddau amddiffyn		
-84230	842	Justice and judicial activities	Gweithgareddau cyfiawnder a barnwrol		
-84240	842	Public order and safety activities	Gweithgareddau'r drefn gyhoeddus a diogelwch		
-84250	842	Fire service activities	Gweithgareddau gwasanaethau tân		
-843	84	Compulsory social security activities			
-84300	843	Compulsory social security activities	Gweithgareddau gorfodol nawdd cymdeithasol		
+84.1	84	Administration of the State and the economic and social policy of the community			
+84.11	84.1	General public administration activities	Gweithgareddau cyffredinol ym maes gweinyddiaeth gyhoeddus		
+84.12	84.1	Regulation of health care, education, cultural and other social services, not incl. social security	Rheoleiddio gofal iechyd, addysg, diwylliant a gwasanaethau cymdeithasol eraill, heblaw nawdd cymdeithasol		
+84.13	84.1	Regulation of and contribution to more efficient operation of businesses	Rheoleiddio busnesau a'u helpu i weithredu'n fwy effeithlon		
+84.2	84	Provision of services to the community as a whole			
+84.21	84.2	Foreign affairs	Materion tramor		
+84.22	84.2	Defence activities	Gweithgareddau amddiffyn		
+84.23	84.2	Justice and judicial activities	Gweithgareddau cyfiawnder a barnwrol		
+84.24	84.2	Public order and safety activities	Gweithgareddau'r drefn gyhoeddus a diogelwch		
+84.25	84.2	Fire service activities	Gweithgareddau gwasanaethau tân		
+84.3	84	Compulsory social security activities			
+84.30	84.3	Compulsory social security activities	Gweithgareddau gorfodol nawdd cymdeithasol		
 85	P	Education			
-851	85	Pre-primary education			
-85100	851	Pre-primary education	Addysg cyn oedran cynradd		
-852	85	Primary education			
-85200	852	Primary education	Addysg gynradd		
-853	85	Secondary education			
-85310	853	General secondary education	Addysg uwchradd gyffredinol		
-85320	853	Technical and vocational secondary education	Addysg uwchradd dechnegol a galwedigaethol		
-854	85	Higher education			
-85410	854	Post-secondary non-tertiary education	Addysg ôl-uwchradd nad yw'n drydyddol		
-85420	854	Tertiary education			
-85421	85420	First-degree level higher education	Addysg uwch lefel gradd gyntaf		
-85422	85420	Post-graduate level higher education	Addysg uwch lefel olraddedig		
-855	85	Other education			
-85510	855	Sports and recreation education	Addysg chwaraeon a hamdden		
-85520	855	Cultural education	Addysg ddiwylliannol		
-85530	855	Driving school activities	Gweithgareddau ysgolion gyrru		
-85590	855	Other education not elsewhere classified	Addysg arall n.dd.b.		
-856	85	Educational support activities			
-85600	856	Educational support services	Gwasanaethau cymorth addysg		
+85.1	85	Pre-primary education			
+85.10	85.1	Pre-primary education	Addysg cyn oedran cynradd		
+85.2	85	Primary education			
+85.20	85.2	Primary education	Addysg gynradd		
+85.3	85	Secondary education			
+85.31	85.3	General secondary education	Addysg uwchradd gyffredinol		
+85.32	85.3	Technical and vocational secondary education	Addysg uwchradd dechnegol a galwedigaethol		
+85.4	85	Higher education			
+85.41	85.4	Post-secondary non-tertiary education	Addysg ôl-uwchradd nad yw'n drydyddol		
+85.42	85.4	Tertiary education			
+85.42/1	85.42	First-degree level higher education	Addysg uwch lefel gradd gyntaf		
+85.42/2	85.42	Post-graduate level higher education	Addysg uwch lefel olraddedig		
+85.5	85	Other education			
+85.51	85.5	Sports and recreation education	Addysg chwaraeon a hamdden		
+85.52	85.5	Cultural education	Addysg ddiwylliannol		
+85.53	85.5	Driving school activities	Gweithgareddau ysgolion gyrru		
+85.59	85.5	Other education not elsewhere classified	Addysg arall n.dd.b.		
+85.6	85	Educational support activities			
+85.60	85.6	Educational support services	Gwasanaethau cymorth addysg		
 86	Q	Human health activities			
-861	86	Hospital activities			
-86100	861	Hospital activities			
-86101	86100	Hospital activities	Gweithgareddau ysbytai		
-86102	86100	Medical nursing home activities	Gweithgareddau cartrefi nyrsio meddygol		
-862	86	Medical and dental practice activities			
-86210	862	General medical practice activities	Gweithgareddau practisau meddygol cyffredinol		
-86220	862	Specialists medical practice activities	Gweithgareddau practisau meddygol arbenigol		
-86230	862	Dental practice activities	Gweithgareddau practisau deintyddol		
-869	86	Other human health activities			
-86900	869	Other human health activities	Gweithgareddau eraill ym maes iechyd y cyhoedd		
+86.1	86	Hospital activities			
+86.10	86.1	Hospital activities			
+86.10/1	86.10	Hospital activities	Gweithgareddau ysbytai		
+86.10/2	86.10	Medical nursing home activities	Gweithgareddau cartrefi nyrsio meddygol		
+86.2	86	Medical and dental practice activities			
+86.21	86.2	General medical practice activities	Gweithgareddau practisau meddygol cyffredinol		
+86.22	86.2	Specialists medical practice activities	Gweithgareddau practisau meddygol arbenigol		
+86.23	86.2	Dental practice activities	Gweithgareddau practisau deintyddol		
+86.9	86	Other human health activities			
+86.90	86.9	Other human health activities	Gweithgareddau eraill ym maes iechyd y cyhoedd		
 87	Q	Residential care activities			
-871	87	Residential nursing care activities			
-87100	871	Residential nursing care facilities	Cyfleusterau gofal nyrsio preswyl		
-872	87	Residential care activities for learning disabilities, mental health and substance abuse			
-87200	872	Residential care activities for learning difficulties, mental health and substance abuse	Gweithgareddau gofal preswyl ar gyfer anawsterau dysgu, iechyd meddwl a cham-drin sylweddau		
-873	87	Residential care activities for the elderly and disabled			
-87300	873	Residential care activities for the elderly and disabled	Gweithgareddau gofal preswyl ar gyfer pobl oedrannus ac anabl		
-879	87	Other residential care activities			
-87900	879	Other residential care activities not elsewhere classified	Gweithgareddau eraill ym maes gofal preswyl n.dd.b.		
+87.1	87	Residential nursing care activities			
+87.10	87.1	Residential nursing care facilities	Cyfleusterau gofal nyrsio preswyl		
+87.2	87	Residential care activities for learning disabilities, mental health and substance abuse			
+87.20	87.2	Residential care activities for learning difficulties, mental health and substance abuse	Gweithgareddau gofal preswyl ar gyfer anawsterau dysgu, iechyd meddwl a cham-drin sylweddau		
+87.3	87	Residential care activities for the elderly and disabled			
+87.30	87.3	Residential care activities for the elderly and disabled	Gweithgareddau gofal preswyl ar gyfer pobl oedrannus ac anabl		
+87.9	87	Other residential care activities			
+87.90	87.9	Other residential care activities not elsewhere classified	Gweithgareddau eraill ym maes gofal preswyl n.dd.b.		
 88	Q	Social work activities without accommodation			
-881	88	Social work activities without accommodation for the elderly and disabled			
-88100	881	Social work activities without accommodation for the elderly and disabled	Gweithgareddau gwaith cymdeithasol heb lety ar gyfer pobl oedrannus ac anabl		
-889	88	Other social work activities without accommodation			
-88910	889	Child day-care activities	Gweithgareddau gofal dydd i blant		
-88990	889	Other social work activities without accommodation not elsewhere classified	Gweithgareddau gofal cymdeithasol eraill heb lety n.dd.b.		
+88.1	88	Social work activities without accommodation for the elderly and disabled			
+88.10	88.1	Social work activities without accommodation for the elderly and disabled	Gweithgareddau gwaith cymdeithasol heb lety ar gyfer pobl oedrannus ac anabl		
+88.9	88	Other social work activities without accommodation			
+88.91	88.9	Child day-care activities	Gweithgareddau gofal dydd i blant		
+88.99	88.9	Other social work activities without accommodation not elsewhere classified	Gweithgareddau gofal cymdeithasol eraill heb lety n.dd.b.		
 90	R	Creative, arts and entertainment activities			
-900	90	Creative, arts and entertainment activities			
-90010	900	Performing arts	Y celfyddydau perfformio		
-90020	900	Support activities to performing arts	Gweithgareddau cymorth ym maes y celfyddydau perfformio		
-90030	900	Artistic creation	Creu artistig		
-90040	900	Operation of arts facilities	Rheoli cyfleusterau ar gyfer y celfyddydau		
+90.0	90	Creative, arts and entertainment activities			
+90.01	90.0	Performing arts	Y celfyddydau perfformio		
+90.02	90.0	Support activities to performing arts	Gweithgareddau cymorth ym maes y celfyddydau perfformio		
+90.03	90.0	Artistic creation	Creu artistig		
+90.04	90.0	Operation of arts facilities	Rheoli cyfleusterau ar gyfer y celfyddydau		
 91	R	Libraries, archives, museums and other cultural activities			
-910	91	Libraries, archives, museums and other cultural activities			
-91010	910	Library and archive activities			
-91011	91010	Library activities	Gweithgareddau llyfrgelloedd		
-91012	91010	Archives activities	Gweithgareddau archifau		
-91020	910	Museums activities	Gweithgareddau amgueddfeydd		
-91030	910	Operation of historical sites and buildings and similar visitor attractions	Gweithredu safleoedd ac adeiladau hanesyddol ac atyniadau tebyg i ymwelwyr		
-91040	910	Botanical and zoological gardens and nature reserves activities	Gweithgareddau gerddi botanegol a sŵolegol a gwarchodfeydd natur		
+91.0	91	Libraries, archives, museums and other cultural activities			
+91.01	91.0	Library and archive activities			
+91.01/1	91.01	Library activities	Gweithgareddau llyfrgelloedd		
+91.01/2	91.01	Archives activities	Gweithgareddau archifau		
+91.02	91.0	Museums activities	Gweithgareddau amgueddfeydd		
+91.03	91.0	Operation of historical sites and buildings and similar visitor attractions	Gweithredu safleoedd ac adeiladau hanesyddol ac atyniadau tebyg i ymwelwyr		
+91.04	91.0	Botanical and zoological gardens and nature reserves activities	Gweithgareddau gerddi botanegol a sŵolegol a gwarchodfeydd natur		
 92	R	Gambling and betting activities			
-920	92	Gambling and betting activities			
-92000	920	Gambling and betting activities	Gweithgareddau gamblo a betio		
+92.0	92	Gambling and betting activities			
+92.00	92.0	Gambling and betting activities	Gweithgareddau gamblo a betio		
 93	R	Sports activities and amusement and recreation activities			
-931	93	Sports activities			
-93110	931	Operation of sports facilities	Gweithredu cyfleusterau chwaraeon		
-93120	931	Activities of sport clubs	Gweithgareddau clybiau chwaraeon		
-93130	931	Fitness facilities	Cyfleusterau ffitrwydd		
-93190	931	Other sports activities			
-93191	93190	Activities of racehorse owners	Gweithgareddau perchnogion ceffylau rasio		
-93199	93190	Other sports activities	Gweithgareddau chwaraeon eraill		
-932	93	Amusement and recreation activities			
-93210	932	Activities of amusement parks and theme parks	Gweithgareddau parciau diddanu a pharciau thema		
-93290	932	Other amusement and recreation activities not elsewhere classified	Gweithgareddau diddanu a hamdden eraill n.dd.b.		
+93.1	93	Sports activities			
+93.11	93.1	Operation of sports facilities	Gweithredu cyfleusterau chwaraeon		
+93.12	93.1	Activities of sport clubs	Gweithgareddau clybiau chwaraeon		
+93.13	93.1	Fitness facilities	Cyfleusterau ffitrwydd		
+93.19	93.1	Other sports activities			
+93.19/1	93.19	Activities of racehorse owners	Gweithgareddau perchnogion ceffylau rasio		
+93.19/9	93.19	Other sports activities	Gweithgareddau chwaraeon eraill		
+93.2	93	Amusement and recreation activities			
+93.21	93.2	Activities of amusement parks and theme parks	Gweithgareddau parciau diddanu a pharciau thema		
+93.29	93.2	Other amusement and recreation activities not elsewhere classified	Gweithgareddau diddanu a hamdden eraill n.dd.b.		
 94	S	Activities of membership organisations			
-941	94	Activities of business, employers and professional membership organisations			
-94110	941	Activities of business and employers membership organisations	Gweithgareddau sefydliadau i aelodau ym myd busnes a chyflogwyr		
-94120	941	Activities of professional membership organisations	Gweithgareddau sefydliadau proffesiynol i aelodau		
-942	94	Activities of trade unions			
-94200	942	Activities of trade unions	Gweithgareddau undebau llafur		
-949	94	Activities of other membership organisations			
-94910	949	Activities of religious organisations	Gweithgareddau sefydliadau crefyddol		
-94920	949	Activities of political organisations	Gweithgareddau sefydliadau gwleidyddol		
-94990	949	Activities of other membership organisations not elsewhere classified	Gweithgareddau sefydliadau aelodaeth eraill n.dd.b.		
+94.1	94	Activities of business, employers and professional membership organisations			
+94.11	94.1	Activities of business and employers membership organisations	Gweithgareddau sefydliadau i aelodau ym myd busnes a chyflogwyr		
+94.12	94.1	Activities of professional membership organisations	Gweithgareddau sefydliadau proffesiynol i aelodau		
+94.2	94	Activities of trade unions			
+94.20	94.2	Activities of trade unions	Gweithgareddau undebau llafur		
+94.9	94	Activities of other membership organisations			
+94.91	94.9	Activities of religious organisations	Gweithgareddau sefydliadau crefyddol		
+94.92	94.9	Activities of political organisations	Gweithgareddau sefydliadau gwleidyddol		
+94.99	94.9	Activities of other membership organisations not elsewhere classified	Gweithgareddau sefydliadau aelodaeth eraill n.dd.b.		
 95	S	Repair of computers and personal and household goods			
-951	95	Repair of computers and communication equipment			
-95110	951	Repair of computers and peripheral equipment	Atgyweirio cyfrifiaduron a'u perifferolion		
-95120	951	Repair of communication equipment	Atgyweirio cyfarpar cyfathrebu		
-952	95	Repair of personal and household goods			
-95210	952	Repair of consumer electronics	Atgyweirio cyfarpar electronig i ddefnyddwyr		
-95220	952	Repair of household appliances and home and garden equipment	Atgyweirio dyfeisiau cartref a chyfarpar y cartref a'r ardd		
-95230	952	Repair of footwear and leather goods	Atgyweirio esgidiau a nwyddau lledr		
-95240	952	Repair of furniture and home furnishings	Atgyweirio celfi ac eitemau dodrefnu'r cartref		
-95250	952	Repair of watches, clocks and jewellery	Atgyweirio watsys, clociau a gemwaith		
-95290	952	Repair of personal and household goods not elsewhere classified	Atgyweirio nwyddau personol a chartref eraill n.dd.b.		
+95.1	95	Repair of computers and communication equipment			
+95.11	95.1	Repair of computers and peripheral equipment	Atgyweirio cyfrifiaduron a'u perifferolion		
+95.12	95.1	Repair of communication equipment	Atgyweirio cyfarpar cyfathrebu		
+95.2	95	Repair of personal and household goods			
+95.21	95.2	Repair of consumer electronics	Atgyweirio cyfarpar electronig i ddefnyddwyr		
+95.22	95.2	Repair of household appliances and home and garden equipment	Atgyweirio dyfeisiau cartref a chyfarpar y cartref a'r ardd		
+95.23	95.2	Repair of footwear and leather goods	Atgyweirio esgidiau a nwyddau lledr		
+95.24	95.2	Repair of furniture and home furnishings	Atgyweirio celfi ac eitemau dodrefnu'r cartref		
+95.25	95.2	Repair of watches, clocks and jewellery	Atgyweirio watsys, clociau a gemwaith		
+95.29	95.2	Repair of personal and household goods not elsewhere classified	Atgyweirio nwyddau personol a chartref eraill n.dd.b.		
 96	S	Other personal service activities			
-960	96	Other personal service activities			
-96010	960	Washing and (dry-)cleaning of textile and fur products	Golchi a glanhau (sychlanhau) cynhyrchion tecstilau a ffwr		
-96020	960	Hairdressing and other beauty treatment	Trin gwallt a thriniaethau harddwch eraill		
-96030	960	Funeral and related activities	Angladdau a gweithgareddau cysylltiedig		
-96040	960	Physical well-being activities	Gweithgareddau lles corfforol		
-96090	960	Other service activities not elsewhere classified	Gweithgareddau gwasanaethau eraill n.dd.b.		
+96.0	96	Other personal service activities			
+96.01	96.0	Washing and (dry-)cleaning of textile and fur products	Golchi a glanhau (sychlanhau) cynhyrchion tecstilau a ffwr		
+96.02	96.0	Hairdressing and other beauty treatment	Trin gwallt a thriniaethau harddwch eraill		
+96.03	96.0	Funeral and related activities	Angladdau a gweithgareddau cysylltiedig		
+96.04	96.0	Physical well-being activities	Gweithgareddau lles corfforol		
+96.09	96.0	Other service activities not elsewhere classified	Gweithgareddau gwasanaethau eraill n.dd.b.		
 97	T	Activities of households as employers of domestic personnel			
-970	97	Activities of households as employers of domestic personnel			
-97000	970	Activities of households as employers of domestic personnel	Gweithgareddau aelwydydd fel cyflogwyr gweithwyr domestig		
+97.0	97	Activities of households as employers of domestic personnel			
+97.00	97.0	Activities of households as employers of domestic personnel	Gweithgareddau aelwydydd fel cyflogwyr gweithwyr domestig		
 98	T	Undifferentiated goods- and services-producing activities of private households for own use			
-981	98	Undifferentiated goods-producing activities of private households for own use			
-98100	981	Undifferentiated goods-producing activities of private households for own use	Gweithgareddau diwahaniaeth aelwydydd preifat i gynhyrchu nwyddau at eu defnydd eu hunain		
-982	98	Undifferentiated service-producing activities of private households for own use			
-98200	982	Undifferentiated service-producing activities of private households for own use	Gweithgareddau diwahaniaeth aelwydydd preifat i gynhyrchu gwasanaethau at eu defnydd eu hunain		
+98.1	98	Undifferentiated goods-producing activities of private households for own use			
+98.10	98.1	Undifferentiated goods-producing activities of private households for own use	Gweithgareddau diwahaniaeth aelwydydd preifat i gynhyrchu nwyddau at eu defnydd eu hunain		
+98.2	98	Undifferentiated service-producing activities of private households for own use			
+98.20	98.2	Undifferentiated service-producing activities of private households for own use	Gweithgareddau diwahaniaeth aelwydydd preifat i gynhyrchu gwasanaethau at eu defnydd eu hunain		
 99	U	Activities of extraterritorial organisations and bodies			
-990	99	Activities of extraterritorial organisations and bodies			
-99000	990	Activities of extraterritorial organisations and bodies	Gweithgareddau sefydliadau a chyrff alldiriogaethol		
+99.0	99	Activities of extraterritorial organisations and bodies			
+99.00	99.0	Activities of extraterritorial organisations and bodies	Gweithgareddau sefydliadau a chyrff alldiriogaethol		
 A		Agriculture, Forestry and Fishing	Amaethyddiaeth, Coedwigaeth a Physgota		
 B		Mining and Quarrying	Mwyngloddio a Chwarela		
 C		Manufacturing	Gweithgynhyrchu		


### PR DESCRIPTION
After feedback from our custodian we've moved back to using the SIC code as-is, including punctuation.

This means building an index or map to match the SIC format used by Companies House data, but provides the standard code used in ONS and other publications across government and from third-parties.